### PR TITLE
Make {un,}border work on views and layer expressions

### DIFF
--- a/commands/FBDisplayCommands.py
+++ b/commands/FBDisplayCommands.py
@@ -44,8 +44,8 @@ class FBDrawBorderCommand(fb.FBCommand):
 
   def run(self, args, options):
     layer = viewHelpers.convertToLayer(args[0])
-    lldb.debugger.HandleCommand('expr (void)[(CALayer *)[%s layer] setBorderWidth:%s]' % (layer, options.width))
-    lldb.debugger.HandleCommand('expr (void)[(CALayer *)[%s layer] setBorderColor:(CGColorRef)[(id)[UIColor %sColor] CGColor]]' % (object, options.color))
+    lldb.debugger.HandleCommand('expr (void)[%s setBorderWidth:%s]' % (layer, options.width))
+    lldb.debugger.HandleCommand('expr (void)[%s setBorderColor:(CGColorRef)[(id)[UIColor %sColor] CGColor]]' % (layer, options.color))
     lldb.debugger.HandleCommand('caflush')
 
 
@@ -61,7 +61,7 @@ class FBRemoveBorderCommand(fb.FBCommand):
 
   def run(self, args, options):
     layer = viewHelpers.convertToLayer(args[0])
-    lldb.debugger.HandleCommand('expr (void)[(CALayer *)[%s layer] setBorderWidth:%s]' % (layer, 0))
+    lldb.debugger.HandleCommand('expr (void)[%s setBorderWidth:%s]' % (layer, 0))
     lldb.debugger.HandleCommand('caflush')
 
 


### PR DESCRIPTION
This does the following:
1. Documents the type of the `viewOrLayer` argument.
2. Uses the recently added `convertToLayer` function to actually allow `border` to be called with either a view or a layer.
