### PR TITLE
Check vc is not nil to prevent infinite recursion

### DIFF
--- a/fblldbviewcontrollerhelpers.py
+++ b/fblldbviewcontrollerhelpers.py
@@ -39,7 +39,7 @@ def _recursiveViewControllerDescriptionWithPrefixAndChildPrefix(vc, string, pref
     viewController = fb.evaluateExpression('(id)[(id)[%s childViewControllers] objectAtIndex:%d]' % (vc, i))
     s += _recursiveViewControllerDescriptionWithPrefixAndChildPrefix(viewController, string, nextPrefix, nextPrefix)
 
-  isModal = fb.evaluateBooleanExpression('((id)[(id)[(id)%s presentedViewController] presentingViewController]) == %s' % (vc, vc))
+  isModal = fb.evaluateBooleanExpression('%s != nil && ((id)[(id)[(id)%s presentedViewController] presentingViewController]) == %s' % (vc, vc, vc))
 
   if isModal:
     modalVC = fb.evaluateObjectExpression('(id)[(id)%s presentedViewController]' % (vc))


### PR DESCRIPTION
If vc is nil then `[[vc presentedViewController] presentingViewController] == vc` returns true, so this function recurses endlessly.

Steps to reproduce:
1. Create a new project in Xcode, choose iOS > Single View Application
2. In the generated view controller class, set a breakpoint in -viewDidLoad on the call to [super viewDidLoad]
3. Run the app in the simulator
4. When the breakpoint is hit, type `pvc` in the console
