### PR TITLE
showview command uses a category method

### DIFF
--- a/commands/FBVisualizationCommands.py
+++ b/commands/FBVisualizationCommands.py
@@ -40,7 +40,7 @@ def _showImage(commandForImage):
 def _showLayer(layer):
   layer = '(' + layer + ')'
 
-  lldb.debugger.HandleCommand('expr (void)UIGraphicsBeginImageContext(((CGRect)[(id)' + layer + ' frame]).size)')
+  lldb.debugger.HandleCommand('expr (void)UIGraphicsBeginImageContextWithOptions(((CGRect)[(id)' + layer + ' frame]).size, NO, 0)')
   lldb.debugger.HandleCommand('expr (void)[(id)' + layer + ' renderInContext:(void *)UIGraphicsGetCurrentContext()]')
 
   frame = lldb.debugger.GetSelectedTarget().GetProcess().GetSelectedThread().GetSelectedFrame()


### PR DESCRIPTION
Right now `showview` calls `-[UIView screenshotImageOfRect:]` which I’m guessing is a category method you have. Instead of that, how about spinning up a graphics context and using `drawViewHierarchyInRect:`?
