### PR TITLE
Cast the border/unborder width input to CGFloat

### DIFF
--- a/commands/FBDisplayCommands.py
+++ b/commands/FBDisplayCommands.py
@@ -44,7 +44,7 @@ class FBDrawBorderCommand(fb.FBCommand):
 
   def run(self, args, options):
     layer = viewHelpers.convertToLayer(args[0])
-    lldb.debugger.HandleCommand('expr (void)[%s setBorderWidth:%s]' % (layer, options.width))
+    lldb.debugger.HandleCommand('expr (void)[%s setBorderWidth:(CGFloat)%s]' % (layer, options.width))
     lldb.debugger.HandleCommand('expr (void)[%s setBorderColor:(CGColorRef)[(id)[UIColor %sColor] CGColor]]' % (layer, options.color))
     lldb.debugger.HandleCommand('caflush')
 
@@ -61,7 +61,7 @@ class FBRemoveBorderCommand(fb.FBCommand):
 
   def run(self, args, options):
     layer = viewHelpers.convertToLayer(args[0])
-    lldb.debugger.HandleCommand('expr (void)[%s setBorderWidth:%s]' % (layer, 0))
+    lldb.debugger.HandleCommand('expr (void)[%s setBorderWidth:(CGFloat)%s]' % (layer, 0))
     lldb.debugger.HandleCommand('caflush')
 
 


### PR DESCRIPTION
Tl;dr: with this fix it's possible to use `border UIButton` (and probably other UIView subclass objects) without passing the layer

I was trying to use `border` on a UIButton: using `border button.layer` was working, `border button` wasn't.
So I started to debugging it: after using `border button`, printing `po button.layer` I noticed that it wasn't setting the border width.
So, in `FBDisplayCommands.py` I changed
`lldb.debugger.HandleCommand('expr (void)[%s setBorderWidth:%s]' % (layer, options.width))`
in
`lldb.debugger.HandleCommand('expr (void)[%s setBorderWidth:%s]' % (layer, 2.0))`.
A new `po button.layer` revealed the mistake:

`<CALayer:0x8b94770; ...borderWidth = 2.8026e-45>`

Casting the `options.width` to `CGFloat` solved the issue.

Note: `unborder button` was working, but I think it's better to cast the width to `CGFloat` in any case.
