### PR TITLE
Fixed issues which prevented show view and layer commands from working on 64 bits

### DIFF
--- a/commands/FBVisualizationCommands.py
+++ b/commands/FBVisualizationCommands.py
@@ -40,7 +40,7 @@ def _showImage(commandForImage):
 def _showLayer(layer):
   layer = '(' + layer + ')'
 
-  lldb.debugger.HandleCommand('expr (void)UIGraphicsBeginImageContextWithOptions(((CGRect)[(id)' + layer + ' bounds]).size, NO, 0)')
+  lldb.debugger.HandleCommand('expr (void)UIGraphicsBeginImageContextWithOptions(((CGRect)[(id)' + layer + ' bounds]).size, NO, 0.0)')
   lldb.debugger.HandleCommand('expr (void)[(id)' + layer + ' renderInContext:(void *)UIGraphicsGetCurrentContext()]')
 
   frame = lldb.debugger.GetSelectedTarget().GetProcess().GetSelectedThread().GetSelectedFrame()


### PR DESCRIPTION
1. Replaced `frame` with `bounds`. Without it, a process started growing memory. Xcode either did not respond when I attempted to stop the process, or Xcode crashed if it successfully stopped the process.
2. Replaced `0` with `0.0`. Without it, the context was not created.
