### PR TITLE
fix bug in example defining a custom command

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ import fblldbbase as fb
 def lldbcommands():
   return [ PrintKeyWindowLevel() ]
   
-class PrintCurrentWindowLevel(fb.FBCommand):
+class PrintKeyWindowLevel(fb.FBCommand):
   def name(self):
     return 'pkeywinlevel'
     


### PR DESCRIPTION
Example code in readme used two different names for the class defining
the example code, resulting in an error when attempting to load the new
command.

This fix just updates the code to use the same name consistently, so
that the example works.
