### PR TITLE
Enabled visualize command to work on devices

### DIFF
--- a/commands/FBVisualizationCommands.py
+++ b/commands/FBVisualizationCommands.py
@@ -120,7 +120,7 @@ def _visualize(target):
       elif _dataIsString(target):
         lldb.debugger.HandleCommand('po (NSString*)[[NSString alloc] initWithData:' + target + ' encoding:4]')
       else:
-          print 'Data isn\'t an image and isn\'t a string.';
+        print 'Data isn\'t an image and isn\'t a string.';
     else:
       print '{} isn\'t supported. You can visualize UIImage, CGImageRef, UIView, CALayer or NSData.'.format(objectHelpers.className(target))
 


### PR DESCRIPTION
This is an improved version of #18 by @bencochran. (It looked like he’s not available to work on it further for now, so I decided to do it). Now both local and remote images are saved to disk using one method, by reading memory from process. What do you think?
