### PR TITLE
Add Auto Layout trace command

### DIFF
--- a/commands/FBPrintCommands.py
+++ b/commands/FBPrintCommands.py
@@ -27,6 +27,7 @@ def lldbcommands():
     FBPrintOnscreenTableViewCells(),
     FBPrintInternals(),
     FBPrintInstanceVariable(),
+    FBPrintAutolayoutTrace(),
   ]
 
 class FBPrintViewHierarchyCommand(fb.FBCommand):
@@ -242,3 +243,17 @@ class FBPrintInstanceVariable(fb.FBCommand):
 
     printCommand = 'po' if ('@' in ivarTypeEncodingFirstChar) else 'p'
     lldb.debugger.HandleCommand('{} (({} *)({}))->{}'.format(printCommand, objectClass, object, ivarName))
+
+
+class FBPrintAutolayoutTrace(fb.FBCommand):
+  def name(self):
+    return 'paltrace'
+
+  def description(self):
+    return "Print the Auto Layout trace for the given view. Defaults to the key window."
+
+  def args(self):
+    return [ fb.FBCommandArgument(arg='view', type='UIView *', help='The view to print the Auto Layout trace for.', default='(id)[[UIApplication sharedApplication] keyWindow]') ]
+
+  def run(self, arguments, options):
+    lldb.debugger.HandleCommand('po (id)[{} _autolayoutTrace]'.format(arguments[0]))


### PR DESCRIPTION
Test plan: Run an app on device or simulator. Pause debugger. Type 'paltrace'. Check that the auto layout trace is printed.
