### PR TITLE
Add depth parameter to pviews

### DIFF
--- a/commands/FBPrintCommands.py
+++ b/commands/FBPrintCommands.py
@@ -38,21 +38,32 @@ class FBPrintViewHierarchyCommand(fb.FBCommand):
     return 'Print the recursion description of <aView>.'
 
   def options(self):
-    return [ fb.FBCommandArgument(short='-u', long='--up', arg='upwards', boolean=True, default=False, help='Print only the hierarchy directly above the view, up to its window.') ]
+    return [
+      fb.FBCommandArgument(short='-u', long='--up', arg='upwards', boolean=True, default=False, help='Print only the hierarchy directly above the view, up to its window.'),
+      fb.FBCommandArgument(short='-d', long='--depth', arg='depth', type='int', default="0", help='Print only to a given depth. 0 indicates infinite depth.'),
+    ]
 
   def args(self):
     return [ fb.FBCommandArgument(arg='aView', type='UIView*', help='The view to print the description of.', default='(id)[UIWindow keyWindow]') ]
 
   def run(self, arguments, options):
+    maxDepth = int(options.depth)
+
     if options.upwards:
       view = arguments[0]
-      description = viewHelpers.upwardsRecursiveDescription(view)
+      description = viewHelpers.upwardsRecursiveDescription(view, maxDepth)
       if description:
         print description
       else:
         print 'Failed to walk view hierarchy. Make sure you pass a view, not any other kind of object or expression.'
     else:
-      lldb.debugger.HandleCommand('po (id)[' + arguments[0] + ' recursiveDescription]')
+      description = fb.evaluateExpressionValue('(id)[' + arguments[0] + ' recursiveDescription]').GetObjectDescription()
+      if maxDepth > 0:
+        separator = re.escape("   | ")
+        prefixToRemove = separator * maxDepth + " "
+        description += "\n"
+        description = re.sub(r'%s.*\n' % (prefixToRemove), r'', description)
+      print description
 
 
 class FBPrintCoreAnimationTree(fb.FBCommand):

--- a/fblldbviewhelpers.py
+++ b/fblldbviewhelpers.py
@@ -55,14 +55,17 @@ def convertToLayer(viewOrLayer):
   else:
     raise Exception('Argument must be a CALayer or a UIView')
 
-def upwardsRecursiveDescription(view):
+def upwardsRecursiveDescription(view, maxDepth=0):
   if not fb.evaluateBooleanExpression('[(id)%s isKindOfClass:(Class)[UIView class]]' % view):
     return None
   
   currentView = view
   recursiveDescription = []
+  depth = 0
   
-  while currentView:
+  while currentView and (maxDepth <= 0 or depth <= maxDepth):
+    depth += 1
+
     viewDescription = fb.evaluateExpressionValue('(id)[%s debugDescription]' % (currentView)).GetObjectDescription()
     currentView = fb.evaluateExpression('(void*)[%s superview]' % (currentView))
     try:


### PR DESCRIPTION
This adds a depth parameter to the `pviews` command. If 0 (the default), then it simply does what it does now. If greater than 0, then it prints only up to a certain depth. This can be useful if you just want to see the top part of the hierarchy.

Example usage:

```
pviews -d 5
pviews someView -d 10
pviews 0xabcd0123 -d 1
```
