### PR TITLE
fix alamborder - missing import

### DIFF
--- a/commands/FBAutoLayoutCommands.py
+++ b/commands/FBAutoLayoutCommands.py
@@ -10,6 +10,7 @@
 
 import lldb
 import fblldbbase as fb
+import fblldbviewhelpers as viewHelpers
 
 def lldbcommands():
   return [


### PR DESCRIPTION
Traceback (most recent call last):
  File "/Users/haikusw/chisel/fblldb.py", line 81, in runCommand
    command.run(args, options)
  File "/Users/haikusw/chisel/commands/FBAutoLayoutCommands.py", line 69, in run
    setBorderOnAmbiguousViewRecursive(keyWindow, options.width, options.color)
  File "/Users/haikusw/chisel/commands/FBAutoLayoutCommands.py", line 42, in setBorderOnAmbiguousViewRecursive
    layer = viewHelpers.convertToLayer(view)
NameError: global name 'viewHelpers' is not defined
