### PR TITLE
pkp: po alternative to lookup via valueForKeyPath:

### DIFF
--- a/commands/FBPrintCommands.py
+++ b/commands/FBPrintCommands.py
@@ -287,10 +287,11 @@ class FBPrintKeyPath(fb.FBCommand):
     ]
 
   def run(self, arguments, options):
-    if len(arguments[0].split('.')) == 1:
-      print '"' + arguments[0] + '" is not a keypath =('
-      return
-
-    object, keypath = arguments[0].split('.', 1)
-    printCommand = 'po [{} valueForKeyPath:@"{}"]'.format(object, keypath)
-    lldb.debugger.HandleCommand(printCommand)
+    command = arguments[0]
+    if len(command.split('.')) == 1:
+      lldb.debugger.HandleCommand("po " + command)
+    else:
+      objectToMessage, keypath = command.split('.', 1)
+      object = fb.evaluateObjectExpression(objectToMessage)
+      printCommand = 'po [{} valueForKeyPath:@"{}"]'.format(object, keypath)
+      lldb.debugger.HandleCommand(printCommand)


### PR DESCRIPTION
pkp is a command to print out a key path.   LLDB has pretty bad . notation resolution, especially through (id) return results, so I've been using [self valueForKeyPath:@"whatever.keypath.failed.inlldb"] to work around this.   This helper makes that very easy!

![screen shot 2014-11-20 at 4 23 12 pm](https://cloud.githubusercontent.com/assets/114322/5133252/a0690ece-70d1-11e4-86b4-3a9549e818a0.png)
