### PR TITLE
Feature: Accessibility Tree printing

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 
 [[Installation](#installation) &bull; [Commands](#commands) &bull; [Custom Commands](#custom-commands) &bull; [Development Workflow](#development-workflow) [Contributing](#contributing) &bull; [License](#license)]
 
+For a comprehensive overview of LLDB, and how Chisel compliments it, read Ari Grant's [Dancing in the Debugger — A Waltz with LLDB](http://www.objc.io/issue-19/lldb-debugging.html) in issue 19 of [objc.io](http://www.objc.io/).
+
 ## Installation
 
 ```

--- a/commands/FBAutoLayoutCommands.py
+++ b/commands/FBAutoLayoutCommands.py
@@ -36,13 +36,13 @@ class FBPrintAutolayoutTrace(fb.FBCommand):
 def setBorderOnAmbiguousViewRecursive(view, width, color):
   if not fb.evaluateBooleanExpression('[(id)%s isKindOfClass:(Class)[UIView class]]' % view):
     return
-  
+
   isAmbiguous = fb.evaluateBooleanExpression('(BOOL)[%s hasAmbiguousLayout]' % view)
   if isAmbiguous:
     layer = viewHelpers.convertToLayer(view)
     lldb.debugger.HandleCommand('expr (void)[%s setBorderWidth:(CGFloat)%s]' % (layer, width))
     lldb.debugger.HandleCommand('expr (void)[%s setBorderColor:(CGColorRef)[(id)[UIColor %sColor] CGColor]]' % (layer, color))
-  
+
   subviews = fb.evaluateExpression('(id)[%s subviews]' % view)
   subviewsCount = int(fb.evaluateExpression('(int)[(id)%s count]' % subviews))
   if subviewsCount > 0:

--- a/commands/FBDisplayCommands.py
+++ b/commands/FBDisplayCommands.py
@@ -46,10 +46,10 @@ class FBDrawBorderCommand(fb.FBCommand):
   def run(self, args, options):
     colorClassName = 'UIColor'
     isMac = runtimeHelpers.isMacintoshArch()
-    
+
     if isMac:
       colorClassName = 'NSColor'
-    
+
     layer = viewHelpers.convertToLayer(args[0])
     lldb.debugger.HandleCommand('expr (void)[%s setBorderWidth:(CGFloat)%s]' % (layer, options.width))
     lldb.debugger.HandleCommand('expr (void)[%s setBorderColor:(CGColorRef)[(id)[%s %sColor] CGColor]]' % (layer, colorClassName, options.color))

--- a/commands/FBFindCommands.py
+++ b/commands/FBFindCommands.py
@@ -98,7 +98,7 @@ def printMatchesInViewOutputStringAndCopyFirstToClipboard(needle, haystack):
     view = match.groups()[-1]
     className = fb.evaluateExpressionValue('(id)[(' + view + ') class]').GetObjectDescription()
     print('{} {}'.format(view, className))
-    if first == None:
+    if first is None:
       first = view
       cmd = 'echo %s | tr -d "\n" | pbcopy' % view
       os.system(cmd)
@@ -125,7 +125,7 @@ class FBFindViewByAccessibilityLabelCommand(fb.FBCommand):
       if re.match(r'.*' + needle + '.*', a11yLabel, re.IGNORECASE):
         print('{} {}'.format(view, a11yLabel))
 
-        if first == None:
+        if first is None:
           first = view
           cmd = 'echo %s | tr -d "\n" | pbcopy' % first
           os.system(cmd)

--- a/commands/FBFlickerCommands.py
+++ b/commands/FBFlickerCommands.py
@@ -110,10 +110,10 @@ class FlickerWalker:
     elif input == 'p':
       recusionName = 'recursiveDescription'
       isMac = runtimeHelpers.isMacintoshArch()
-      
+
       if isMac:
         recursionName = '_subtreeDescription'
-      
+
       lldb.debugger.HandleCommand('po [(id)' + oldView + ' ' + recusionName + ']')
     else:
       print '\nI really have no idea what you meant by \'' + input + '\'... =\\\n'

--- a/commands/FBInvocationCommands.py
+++ b/commands/FBInvocationCommands.py
@@ -89,7 +89,7 @@ def stackStartAddressInSelectedFrame(frame):
     return int(frame.EvaluateExpression('($esp + 8)').GetValue())
   else:
     return int(frame.EvaluateExpression('($ebp + 8)').GetValue())
-    
+
 
 def findArgAtIndexFromStackFrame(frame, index):
   return fb.evaluateExpression('*(int *)' + str(findArgAdressAtIndexFromStackFrame(frame, index)))
@@ -134,36 +134,36 @@ def prettyPrintInvocation(frame, invocation):
         print readableString
       else:
         if encoding[0] == '{':
-          encoding = encoding[1:len(encoding)-1]
+          encoding = encoding[1:]
         print (hex(address) + ', address of ' + encoding + ' ' + description).strip()
 
       index += 1
 
 def argumentAsString(frame, address, encoding):
   if encoding[0] == '{':
-    encoding = encoding[1:len(encoding)-1]
+    encoding = encoding[1:]
 
   encodingMap = {
-    'c' : 'char',
-    'i' : 'int',
-    's' : 'short',
-    'l' : 'long',
-    'q' : 'long long',
+    'c': 'char',
+    'i': 'int',
+    's': 'short',
+    'l': 'long',
+    'q': 'long long',
 
-    'C' : 'unsigned char',
-    'I' : 'unsigned int',
-    'S' : 'unsigned short',
-    'L' : 'unsigned long',
-    'Q' : 'unsigned long long',
+    'C': 'unsigned char',
+    'I': 'unsigned int',
+    'S': 'unsigned short',
+    'L': 'unsigned long',
+    'Q': 'unsigned long long',
 
-    'f' : 'float',
-    'd' : 'double',
-    'B' : 'bool',
-    'v' : 'void',
-    '*' : 'char *',
-    '@' : 'id',
-    '#' : 'Class',
-    ':' : 'SEL',
+    'f': 'float',
+    'd': 'double',
+    'B': 'bool',
+    'v': 'void',
+    '*': 'char *',
+    '@': 'id',
+    '#': 'Class',
+    ':': 'SEL',
   }
 
   pointers = ''
@@ -202,5 +202,5 @@ def argumentAsString(frame, address, encoding):
         description = value.GetSummary()
       if description:
         return type + ': ' + description
-  
+
   return None

--- a/commands/FBPrintCommands.py
+++ b/commands/FBPrintCommands.py
@@ -307,11 +307,11 @@ class FBPrintAccessibilityTree(fb.FBCommand):
     return 'pae'
 
   def description(self):
-    return "Print out the accessibility heirarchy.   Traverses the accessibilityElements if present, otherwise the subviews."
+    return "Print out the accessibility heirarchy.   Traverses the accessibilityElements if present and the accessibility inspector is  enabled, otherwise the subviews."
 
   def args(self):
     return [
-      fb.FBCommandArgument(arg='object', type='id', help='The object to print accessibility information for'),
+      fb.FBCommandArgument(arg='object', type='id', default="[[UIApplication sharedApplication] keyWindow]", help='The object to print accessibility information for'),
     ]
 
   def run(self, arguments, options):

--- a/commands/FBPrintCommands.py
+++ b/commands/FBPrintCommands.py
@@ -287,9 +287,14 @@ class FBPrintKeyPath(fb.FBCommand):
     ]
 
   def run(self, arguments, options):
-    keypath = arguments[0]
-    objectToMessage, keypath = keypath.split('.', 1)
-    object = fb.evaluateObjectExpression(objectToMessage)
+    keys = arguments[0].split('.')
 
-    printCommand = 'po [{} valueForKeyPath:@"{}"]'.format(object, keypath)
+    if keys.count == 1:
+      print '"' + arguments[0] + '" is not a keypath =('
+      return
+
+    object = keys[0]
+    keys = keys[1:len(keys)]
+    keypath = ".".join(keys)
+    printCommand = 'po [(NSObject *){} valueForKeyPath:@"{}"]'.format(object, keypath)
     lldb.debugger.HandleCommand(printCommand)

--- a/commands/FBPrintCommands.py
+++ b/commands/FBPrintCommands.py
@@ -28,6 +28,7 @@ def lldbcommands():
     FBPrintOnscreenTableViewCells(),
     FBPrintInternals(),
     FBPrintInstanceVariable(),
+    FBPrintKeyPath(),
   ]
 
 class FBPrintViewHierarchyCommand(fb.FBCommand):
@@ -272,3 +273,23 @@ class FBPrintInstanceVariable(fb.FBCommand):
 
     printCommand = 'po' if ('@' in ivarTypeEncodingFirstChar) else 'p'
     lldb.debugger.HandleCommand('{} (({} *)({}))->{}'.format(printCommand, objectClass, object, ivarName))
+
+class FBPrintKeyPath(fb.FBCommand):
+  def name(self):
+    return 'pkp'
+
+  def description(self):
+    return "Print out the value of [self valueForKeyPath:<>]."
+
+  def args(self):
+    return [
+      fb.FBCommandArgument(arg='keypath', type='NSString *', help='The keypath to print'),
+    ]
+
+  def run(self, arguments, options):
+    keypath = arguments[0]
+    objectToMessage, keypath = keypath.split('.', 1)
+    object = fb.evaluateObjectExpression(objectToMessage)
+
+    printCommand = 'po [{} valueForKeyPath:@"{}"]'.format(object, keypath)
+    lldb.debugger.HandleCommand(printCommand)

--- a/commands/FBPrintCommands.py
+++ b/commands/FBPrintCommands.py
@@ -279,7 +279,7 @@ class FBPrintKeyPath(fb.FBCommand):
     return 'pkp'
 
   def description(self):
-    return "Print out the value of [self valueForKeyPath:<>]."
+    return "Print out the value of the key path expression using -valueForKeyPath:"
 
   def args(self):
     return [
@@ -287,14 +287,10 @@ class FBPrintKeyPath(fb.FBCommand):
     ]
 
   def run(self, arguments, options):
-    keys = arguments[0].split('.')
-
-    if keys.count == 1:
+    if len(arguments[0].split('.')) == 1:
       print '"' + arguments[0] + '" is not a keypath =('
       return
 
-    object = keys[0]
-    keys = keys[1:len(keys)]
-    keypath = ".".join(keys)
-    printCommand = 'po [(NSObject *){} valueForKeyPath:@"{}"]'.format(object, keypath)
+    object, keypath = arguments[0].split('.', 1)
+    printCommand = 'po [{} valueForKeyPath:@"{}"]'.format(object, keypath)
     lldb.debugger.HandleCommand(printCommand)

--- a/commands/FBPrintCommands.py
+++ b/commands/FBPrintCommands.py
@@ -29,6 +29,7 @@ def lldbcommands():
     FBPrintInternals(),
     FBPrintInstanceVariable(),
     FBPrintKeyPath(),
+    FBPrintAccessibilityTree(),
   ]
 
 class FBPrintViewHierarchyCommand(fb.FBCommand):
@@ -294,3 +295,19 @@ class FBPrintKeyPath(fb.FBCommand):
     object, keypath = arguments[0].split('.', 1)
     printCommand = 'po [{} valueForKeyPath:@"{}"]'.format(object, keypath)
     lldb.debugger.HandleCommand(printCommand)
+
+class FBPrintAccessibilityTree(fb.FBCommand):
+  def name(self):
+    return 'pae'
+
+  def description(self):
+    return "Print out the view heirarchy with accessibility"
+
+  def args(self):
+    return [
+      fb.FBCommandArgument(arg='object', type='id', help='The object to print accessibility information for'),
+    ]
+
+  def run(self, arguments, options):
+    object = fb.evaluateObjectExpression(arguments[0])
+    return viewHelpers.accessibilityRecursiveDescription(object, "")

--- a/commands/FBPrintCommands.py
+++ b/commands/FBPrintCommands.py
@@ -15,6 +15,7 @@ import fblldbbase as fb
 import fblldbviewcontrollerhelpers as vcHelpers
 import fblldbviewhelpers as viewHelpers
 import fblldbobjcruntimehelpers as runtimeHelpers
+import fblldbobjecthelpers as objectHelpers
 
 def lldbcommands():
   return [
@@ -301,7 +302,7 @@ class FBPrintAccessibilityTree(fb.FBCommand):
     return 'pae'
 
   def description(self):
-    return "Print out the view heirarchy with accessibility"
+    return "Print out the accessibility heirarchy.   Traverses the accessibilityElements if present, otherwise the subviews."
 
   def args(self):
     return [

--- a/commands/FBVisualizationCommands.py
+++ b/commands/FBVisualizationCommands.py
@@ -33,13 +33,13 @@ def _showImage(commandForImage):
     else:
       raise
 
-  imageDataAddress = fb.evaluateObjectExpression('UIImagePNGRepresentation((id)' + commandForImage +')')
+  imageDataAddress = fb.evaluateObjectExpression('UIImagePNGRepresentation((id)' + commandForImage + ')')
   imageBytesStartAddress = fb.evaluateExpression('(void *)[(id)' + imageDataAddress + ' bytes]')
   imageBytesLength = fb.evaluateExpression('(NSUInteger)[(id)' + imageDataAddress + ' length]')
 
-  address = int(imageBytesStartAddress,16)
+  address = int(imageBytesStartAddress, 16)
   length = int(imageBytesLength)
-  
+
   if not (address or length):
     print 'Could not get image data.'
     return
@@ -47,7 +47,7 @@ def _showImage(commandForImage):
   process = lldb.debugger.GetSelectedTarget().GetProcess()
   error = lldb.SBError()
   mem = process.ReadMemory(address, length, error)
-  
+
   if error is not None and str(error) != 'success':
     print error
   else:
@@ -76,35 +76,35 @@ def _dataIsImage(data):
   data = '(' + data + ')'
 
   frame = lldb.debugger.GetSelectedTarget().GetProcess().GetSelectedThread().GetSelectedFrame()
-  result = frame.EvaluateExpression('(id)[UIImage imageWithData:' + data + ']');
+  result = frame.EvaluateExpression('(id)[UIImage imageWithData:' + data + ']')
 
   if result.GetError() is not None and str(result.GetError()) != 'success':
-    return 0;
+    return 0
   else:
-    isImage = result.GetValueAsUnsigned() != 0;
+    isImage = result.GetValueAsUnsigned() != 0
     if isImage:
-      return 1;
+      return 1
     else:
-      return 0;
+      return 0
 
 def _dataIsString(data):
   data = '(' + data + ')'
 
   frame = lldb.debugger.GetSelectedTarget().GetProcess().GetSelectedThread().GetSelectedFrame()
-  result = frame.EvaluateExpression('(NSString*)[[NSString alloc] initWithData:' + data + ' encoding:4]');
+  result = frame.EvaluateExpression('(NSString*)[[NSString alloc] initWithData:' + data + ' encoding:4]')
 
   if result.GetError() is not None and str(result.GetError()) != 'success':
-    return 0;
+    return 0
   else:
-    isString = result.GetValueAsUnsigned() != 0;
+    isString = result.GetValueAsUnsigned() != 0
     if isString:
-      return 1;
+      return 1
     else:
-      return 0;
+      return 0
 
 def _visualize(target):
   target = '(' + target + ')'
-  
+
   if fb.evaluateBooleanExpression('(unsigned long)CFGetTypeID((CFTypeRef)' + target + ') == (unsigned long)CGImageGetTypeID()'):
     _showImage('(id)[UIImage imageWithCGImage:' + target + ']')
   else:
@@ -116,11 +116,11 @@ def _visualize(target):
       _showLayer(target)
     elif objectHelpers.isKindOfClass(target, 'NSData'):
       if _dataIsImage(target):
-        _showImage('(id)[UIImage imageWithData:' + target + ']');
+        _showImage('(id)[UIImage imageWithData:' + target + ']')
       elif _dataIsString(target):
         lldb.debugger.HandleCommand('po (NSString*)[[NSString alloc] initWithData:' + target + ' encoding:4]')
       else:
-        print 'Data isn\'t an image and isn\'t a string.';
+        print 'Data isn\'t an image and isn\'t a string.'
     else:
       print '{} isn\'t supported. You can visualize UIImage, CGImageRef, UIView, CALayer or NSData.'.format(objectHelpers.className(target))
 

--- a/fblldb.py
+++ b/fblldb.py
@@ -64,7 +64,7 @@ def makeRunCommand(command, filename):
     # thing.
     options = command.options()
     if len(options) == 0:
-      if not '--' in splitInput:
+      if '--' not in splitInput:
         splitInput.insert(0, '--')
 
     parser = optionParserForCommand(command)
@@ -74,7 +74,7 @@ def makeRunCommand(command, filename):
     # the initial args form an expression and combine them into a single arg.
     if len(args) > len(command.args()):
       overhead = len(args) - len(command.args())
-      head = args[:overhead+1] # Take N+1 and reduce to 1.
+      head = args[:overhead + 1] # Take N+1 and reduce to 1.
       args = [' '.join(head)] + args[-overhead:]
 
     if validateArgsForCommand(args, command):
@@ -145,8 +145,8 @@ def helpForCommand(command, filename):
       help += '; ' + option.help
 
       optionSyntax += ' [{name}{arg}]'.format(
-        name= option.longName or option.shortName,
-        arg = '' if option.boolean else ('=' + option.argName)
+        name=(option.longName or option.shortName),
+        arg=('' if option.boolean else ('=' + option.argName))
       )
 
   help += '\n\nSyntax: ' + command.name() + optionSyntax + argSyntax
@@ -166,4 +166,3 @@ def usageForCommand(command):
       usage += ' ' + arg.argName
 
   return usage
-

--- a/fblldbbase.py
+++ b/fblldbbase.py
@@ -47,11 +47,14 @@ def evaluateExpressionValue(expression, printErrors=True):
 
 def evaluateIntegerExpression(expression, printErrors=True):
   output = evaluateExpression('(int)(' + expression + ')', printErrors).replace('\'', '')
+  value = 0
   if output.startswith('\\x'): # Booleans may display as \x01 (Hex)
-    output = output[2:]
+    value = int(output[2:], 16)
   elif output.startswith('\\'): # Or as \0 (Dec)
-    output = output[1:]
-  return int(output, 16)
+    value = int(output[1:], 10)
+  else:
+    value = int(output, 10)
+  return value
 
 def evaluateBooleanExpression(expression, printErrors=True):
   return (int(evaluateIntegerExpression('(BOOL)(' + expression + ')', printErrors)) != 0)

--- a/fblldbbase.py
+++ b/fblldbbase.py
@@ -35,6 +35,7 @@ class FBCommand:
   def run(self, arguments, option):
     pass
 
+NSNOTFOUND32BIT = 0x7fffffff
 
 def evaluateExpressionValue(expression, printErrors=True):
   # lldb.frame is supposed to contain the right frame, but it doesnt :/ so do the dance

--- a/fblldbbase.py
+++ b/fblldbbase.py
@@ -36,7 +36,7 @@ class FBCommand:
     pass
 
 
-def evaluateExpressionValue(expression, printErrors = True):
+def evaluateExpressionValue(expression, printErrors=True):
   # lldb.frame is supposed to contain the right frame, but it doesnt :/ so do the dance
   frame = lldb.debugger.GetSelectedTarget().GetProcess().GetSelectedThread().GetSelectedFrame()
   value = frame.EvaluateExpression(expression)
@@ -44,7 +44,7 @@ def evaluateExpressionValue(expression, printErrors = True):
     print value.GetError()
   return value
 
-def evaluateIntegerExpression(expression, printErrors = True):
+def evaluateIntegerExpression(expression, printErrors=True):
   output = evaluateExpression('(int)(' + expression + ')', printErrors).replace('\'', '')
   if output.startswith('\\x'): # Booleans may display as \x01 (Hex)
     output = output[2:]
@@ -52,11 +52,11 @@ def evaluateIntegerExpression(expression, printErrors = True):
     output = output[1:]
   return int(output, 16)
 
-def evaluateBooleanExpression(expression, printErrors = True):
+def evaluateBooleanExpression(expression, printErrors=True):
   return (int(evaluateIntegerExpression('(BOOL)(' + expression + ')', printErrors)) != 0)
 
-def evaluateExpression(expression, printErrors = True):
+def evaluateExpression(expression, printErrors=True):
   return evaluateExpressionValue(expression, printErrors).GetValue()
 
-def evaluateObjectExpression(expression, printErrors = True):
+def evaluateObjectExpression(expression, printErrors=True):
   return evaluateExpression('(id)(' + expression + ')', printErrors)

--- a/fblldbinputhelpers.py
+++ b/fblldbinputhelpers.py
@@ -33,9 +33,9 @@ class FBInputHandler:
     self.inputReader.SetIsDone(True)
 
   def handleInput(self, inputReader, notification, bytes):
-    if (notification == lldb.eInputReaderGotToken):
+    if notification == lldb.eInputReaderGotToken:
       self.callback(bytes)
-    elif (notification == lldb.eInputReaderInterrupt):
+    elif notification == lldb.eInputReaderInterrupt:
       self.stop()
-    
+
     return len(bytes)

--- a/fblldbobjcruntimehelpers.py
+++ b/fblldbobjcruntimehelpers.py
@@ -42,7 +42,7 @@ def currentArch():
 
 def functionPreambleExpressionForSelf():
   import re
-  
+
   arch = currentArch()
   expressionForSelf = None
   if arch == 'i386':
@@ -57,22 +57,22 @@ def functionPreambleExpressionForSelf():
 
 def functionPreambleExpressionForObjectParameterAtIndex(parameterIndex):
   import re
-  
+
   arch = currentArch()
   expresssion = None
   if arch == 'i386':
     expresssion = '*(id*)($esp + ' + str(12 + parameterIndex * 4) + ')'
   elif arch == 'x86_64':
-    if (parameterIndex > 3):
+    if parameterIndex > 3:
       raise Exception("Current implementation can not return object at index greater than 3 for arc x86_64")
     registersList = ['rdx', 'rcx', 'r8', 'r9']
     expresssion = '(id)$' + registersList[parameterIndex]
   elif arch == 'arm64':
-    if (parameterIndex > 5):
-      raise Exception("Current implementation can not return object at index greater than 5 for arm64")  
+    if parameterIndex > 5:
+      raise Exception("Current implementation can not return object at index greater than 5 for arm64")
     expresssion = '(id)$x' + str(parameterIndex + 2)
   elif re.match(r'^armv.*$', arch):
-    if (parameterIndex > 3):
+    if parameterIndex > 3:
       raise Exception("Current implementation can not return object at index greater than 1 for arm32")
     expresssion = '(id)$r' + str(parameterIndex + 2)
   return expresssion
@@ -81,8 +81,8 @@ def isMacintoshArch():
   arch = currentArch()
   if not arch == 'x86_64':
     return False
-  
-  nsClassName ='NSApplication'
+
+  nsClassName = 'NSApplication'
   command = '(void*)objc_getClass("{}")'.format(nsClassName)
 
   return (fb.evaluateBooleanExpression(command + '!= nil'))

--- a/fblldbobjecthelpers.py
+++ b/fblldbobjecthelpers.py
@@ -15,4 +15,30 @@ def isKindOfClass(obj, className):
   return fb.evaluateBooleanExpression(isKindOfClassStr.format(className))
 
 def className(obj):
-  return fb.evaluateExpressionValue('(id)[(' + obj + ') class]').GetObjectDescription()
+  return fb.evaluateExpressionValue('(id)[(%s) class]' % (obj)).GetObjectDescription()
+
+def valueForKey(obj, key):
+  return fb.evaluateExpressionValue('(id)[%s valueForKey:@"%s"]' % (obj, key)).GetObjectDescription()
+
+def isNil(obj)
+  return obj == "<nil>" || obj == "<object returned empty description>"
+
+def displayValueForKey(obj, key):
+  value = valueForKey(obj, key)
+  return "{}='{}'".format(key, value) if !isNil(value) else ""
+
+def displayValueForKeys(obj, keys):
+  def displayValueForThisObjectKey(key):
+    return displayValueForKey(obj, key)
+  return " ".join(map(displayValueForThisObjectKey, keys))
+
+def displayObjectWithString(obj, string):
+  return "<{}:{} {}>".format(
+    className(obj),
+    obj,
+    string)
+
+def displayObjectWithKeys(obj, keys):
+  return displayObjectWithString(obj, displayValueForKeys(obj, keys))
+
+  

--- a/fblldbobjecthelpers.py
+++ b/fblldbobjecthelpers.py
@@ -15,7 +15,7 @@ def isKindOfClass(obj, className):
   return fb.evaluateBooleanExpression(isKindOfClassStr.format(className))
 
 def className(obj):
-  return fb.evaluateExpressionValue('(id)[(%s) class]' % (obj)).GetObjectDescription()
+  return fb.evaluateExpressionValue('(id)[(' + obj + ') class]').GetObjectDescription()
 
 def valueForKey(obj, key):
   return fb.evaluateExpressionValue('(id)[%s valueForKey:@"%s"]' % (obj, key)).GetObjectDescription()
@@ -40,5 +40,3 @@ def displayObjectWithString(obj, string):
 
 def displayObjectWithKeys(obj, keys):
   return displayObjectWithString(obj, displayValueForKeys(obj, keys))
-
-  

--- a/fblldbobjecthelpers.py
+++ b/fblldbobjecthelpers.py
@@ -20,12 +20,12 @@ def className(obj):
 def valueForKey(obj, key):
   return fb.evaluateExpressionValue('(id)[%s valueForKey:@"%s"]' % (obj, key)).GetObjectDescription()
 
-def isNil(obj)
-  return obj == "<nil>" || obj == "<object returned empty description>"
+def isNil(obj):
+  return obj == "<nil>" or obj == "<object returned empty description>"
 
 def displayValueForKey(obj, key):
   value = valueForKey(obj, key)
-  return "{}='{}'".format(key, value) if !isNil(value) else ""
+  return "{}='{}'".format(key, value) if not isNil(value) else ""
 
 def displayValueForKeys(obj, keys):
   def displayValueForThisObjectKey(key):

--- a/fblldbviewcontrollerhelpers.py
+++ b/fblldbviewcontrollerhelpers.py
@@ -47,7 +47,7 @@ def _recursiveViewControllerDescriptionWithPrefixAndChildPrefix(vc, string, pref
 
     if isModal:
       modalVC = fb.evaluateObjectExpression('(id)[(id)%s presentedViewController]' % (vc))
-      s += _recursiveViewControllerDescriptionWithPrefixAndChildPrefix(modalVC, string, childPrefix + '  *M' , nextPrefix)
+      s += _recursiveViewControllerDescriptionWithPrefixAndChildPrefix(modalVC, string, childPrefix + '  *M', nextPrefix)
       s += '\n// \'*M\' means the view controller is presented modally.'
 
   return string + s

--- a/fblldbviewhelpers.py
+++ b/fblldbviewhelpers.py
@@ -122,7 +122,7 @@ def accessibilityElementAtIndex(object, index):
 def accessibilityChildren(object):
   accessibilityCount = accessibilityElementCount(object)
   aeChildren = []
-  if accessibilityCount != 0x7fffffff:
+  if accessibilityCount < 0x7fffffff:
     for i in range(0, accessibilityCount):
       aeChildren.append(accessibilityElementAtIndex(object, i))
   return aeChildren

--- a/fblldbviewhelpers.py
+++ b/fblldbviewhelpers.py
@@ -97,19 +97,11 @@ def upwardsRecursiveDescription(view, maxDepth=0):
 def firstHexInDescription(object):
   return re.findall(r'0x[0-9A-F]+', "{}".format(object), re.I)[0]
 
-def evaluateIntegerExpression(expression):
-  output = fb.evaluateExpression('(int)(' + expression + ')', True).replace('\'', '')
-  return int (output, 10)
-
 def accessibilityDescription(object):
   if isAccessibilityElement(object):
     return objectHelpers.displayObjectWithKeys(object, ["accessibilityLabel", "accessibilityValue", "accessibilityHint"])
   else:
     return objectHelpers.displayObjectWithString(object, "isAccessibilityElement=NO")
-
-def accessibilityElementCount(object):
-  cmd = "(int)[%s accessibilityElementCount]" % (object)
-  return evaluateIntegerExpression(cmd)
 
 def isAccessibilityElement(object):
   return fb.evaluateBooleanExpression('[(id)%s isAccessibilityElement]' % object)
@@ -120,7 +112,7 @@ def accessibilityElementAtIndex(object, index):
   return obj
 
 def accessibilityChildren(object):
-  accessibilityCount = accessibilityElementCount(object)
+  accessibilityCount = fb.evaluateIntegerExpression("(int)[%s accessibilityElementCount]" % (object))
   aeChildren = []
   if accessibilityCount < fb.NSNOTFOUND32BIT:
     for i in range(0, accessibilityCount):
@@ -132,7 +124,7 @@ def subviews(view):
   responds = fb.evaluateBooleanExpression('[(id)%s respondsToSelector:(SEL)@selector(subviews)]' % view)
   if responds:
     subviews = fb.evaluateExpression('(id)[%s subviews]' % view)
-    subviewsCount = evaluateIntegerExpression('[(id)%s count]' % subviews)
+    subviewsCount = fb.evaluateIntegerExpression('[(id)%s count]' % subviews)
     if subviewsCount > 0:
       for i in range(0, subviewsCount):
         subview = fb.evaluateExpression('(id)[%s objectAtIndex:%i]' % (subviews, i))

--- a/fblldbviewhelpers.py
+++ b/fblldbviewhelpers.py
@@ -59,11 +59,11 @@ def convertToLayer(viewOrLayer):
 def upwardsRecursiveDescription(view, maxDepth=0):
   if not fb.evaluateBooleanExpression('[(id)%s isKindOfClass:(Class)[UIView class]]' % view) and not fb.evaluateBooleanExpression('[(id)%s isKindOfClass:(Class)[NSView class]]' % view):
     return None
-  
+
   currentView = view
   recursiveDescription = []
   depth = 0
-  
+
   while currentView and (maxDepth <= 0 or depth <= maxDepth):
     depth += 1
 
@@ -74,18 +74,18 @@ def upwardsRecursiveDescription(view, maxDepth=0):
         currentView = None
     except:
       currentView = None
-    
+
     if viewDescription:
       recursiveDescription.insert(0, viewDescription)
 
   if len(viewDescription) == 0:
-  	return None
-  
+    return None
+
   currentPrefix = ""
   builder = ""
   for viewDescription in recursiveDescription:
     builder += currentPrefix + viewDescription + "\n"
-  currentPrefix += "   | "
+    currentPrefix += "   | "
 
   return builder
 

--- a/fblldbviewhelpers.py
+++ b/fblldbviewhelpers.py
@@ -122,7 +122,7 @@ def accessibilityElementAtIndex(object, index):
 def accessibilityChildren(object):
   accessibilityCount = accessibilityElementCount(object)
   aeChildren = []
-  if accessibilityCount < 0x7fffffff:
+  if accessibilityCount < fb.NSNOTFOUND32BIT:
     for i in range(0, accessibilityCount):
       aeChildren.append(accessibilityElementAtIndex(object, i))
   return aeChildren


### PR DESCRIPTION
This is not quite ready, and full of terrible python, but the basics are there.   It's sort of comical how long it takes to run and the amount of commands sent to generate the output.   But I think it will be helpful with some tuning.  Any suggestions would be good to get.

It adds a pae command that prints out the accessibility tree starting from the current object.   If the current object is a UIView, it will also traverse subviews to find accessibility elements, as I *think* that's what voice over is doing.

