### PR TITLE
support x86_64h

### DIFF
--- a/fblldbobjcruntimehelpers.py
+++ b/fblldbobjcruntimehelpers.py
@@ -47,7 +47,7 @@ def functionPreambleExpressionForSelf():
   expressionForSelf = None
   if arch == 'i386':
     expressionForSelf = '*(id*)($esp+4)'
-  elif arch == 'x86_64':
+  elif arch == 'x86_64' or 'x86_64h':
     expressionForSelf = '(id)$rdi'
   elif arch == 'arm64':
     expressionForSelf = '(id)$x0'
@@ -62,7 +62,7 @@ def functionPreambleExpressionForObjectParameterAtIndex(parameterIndex):
   expresssion = None
   if arch == 'i386':
     expresssion = '*(id*)($esp + ' + str(12 + parameterIndex * 4) + ')'
-  elif arch == 'x86_64':
+  elif arch == 'x86_64' or 'x86_64h':
     if parameterIndex > 3:
       raise Exception("Current implementation can not return object at index greater than 3 for arc x86_64")
     registersList = ['rdx', 'rcx', 'r8', 'r9']
@@ -79,7 +79,7 @@ def functionPreambleExpressionForObjectParameterAtIndex(parameterIndex):
 
 def isMacintoshArch():
   arch = currentArch()
-  if not arch == 'x86_64':
+  if not arch == 'x86_64' or 'x86_64h':
     return False
 
   nsClassName = 'NSApplication'

--- a/fblldbobjcruntimehelpers.py
+++ b/fblldbobjcruntimehelpers.py
@@ -38,6 +38,8 @@ def class_getInstanceMethod(klass, selector):
 def currentArch():
   targetTriple = lldb.debugger.GetSelectedTarget().GetTriple()
   arch = targetTriple.split('-')[0]
+  if arch == 'x86_64h':
+    arch = 'x86_64'
   return arch
 
 def functionPreambleExpressionForSelf():
@@ -47,7 +49,7 @@ def functionPreambleExpressionForSelf():
   expressionForSelf = None
   if arch == 'i386':
     expressionForSelf = '*(id*)($esp+4)'
-  elif arch == 'x86_64' or 'x86_64h':
+  elif arch == 'x86_64':
     expressionForSelf = '(id)$rdi'
   elif arch == 'arm64':
     expressionForSelf = '(id)$x0'
@@ -62,7 +64,7 @@ def functionPreambleExpressionForObjectParameterAtIndex(parameterIndex):
   expresssion = None
   if arch == 'i386':
     expresssion = '*(id*)($esp + ' + str(12 + parameterIndex * 4) + ')'
-  elif arch == 'x86_64' or 'x86_64h':
+  elif arch == 'x86_64':
     if parameterIndex > 3:
       raise Exception("Current implementation can not return object at index greater than 3 for arc x86_64")
     registersList = ['rdx', 'rcx', 'r8', 'r9']
@@ -79,7 +81,7 @@ def functionPreambleExpressionForObjectParameterAtIndex(parameterIndex):
 
 def isMacintoshArch():
   arch = currentArch()
-  if not arch == 'x86_64' or 'x86_64h':
+  if not arch == 'x86_64':
     return False
 
   nsClassName = 'NSApplication'


### PR DESCRIPTION
Using OSX Yosemite 10.10.2  and Xcode Version 6.1.1 (6A2008a) my architecture comes up as x86_64h. This leads to the error: `Your architecture, {}, is truly fantastic. However, I don\'t currently support it.`

Adding x86_64h as an option to this file allows chisel to work properly. 