### PR TITLE
Fixed ‘vs’ command by:

### DIFF
--- a/commands/FBFlickerCommands.py
+++ b/commands/FBFlickerCommands.py
@@ -115,7 +115,7 @@ class FlickerWalker:
 
       lldb.debugger.HandleCommand('po [(id)' + oldView + ' ' + recusionName + ']')
     else:
-      print '\nChisel - VS Mode: I really have no idea what you meant by \'' + input + '\'... =\\\n'
+      print '\nI really have no idea what you meant by \'' + input + '\'... =\\\n'
 
   def setCurrentView(self, view, oldView=None):
     if view:

--- a/commands/FBFlickerCommands.py
+++ b/commands/FBFlickerCommands.py
@@ -63,17 +63,17 @@ class FBViewSearchCommand(fb.FBCommand):
 
 class FlickerWalker:
   def __init__(self, startView):
-    self.setCurrentView(startView, None)
+    self.setCurrentView(startView)
 
   def run(self):
     self.keepRunning = True
     initialAsync = lldb.debugger.GetAsync()
-    lldb.debugger.SetAsync(True) #needed so XCode doesn't hang if tap on Continue while lldb is waiting for user input in 'vs' mode
+    lldb.debugger.SetAsync(True) #Needed so XCode doesn't hang if tap on Continue while lldb is waiting for user input in 'vs' mode
     while self.keepRunning:
       charRead = sys.stdin.readline().rstrip("\n")
       self.inputCallback(charRead)
     else:
-      lldb.debugger.SetAsync(initialAsync) #restore to init value
+      lldb.debugger.SetAsync(initialAsync)
 
   def inputCallback(self, input):
     oldView = self.currentView

--- a/commands/FBFlickerCommands.py
+++ b/commands/FBFlickerCommands.py
@@ -67,10 +67,13 @@ class FlickerWalker:
 
   def run(self):
     self.keepRunning = True
-    lldb.debugger.SetAsync (True)
+    initialAsync = lldb.debugger.GetAsync()
+    lldb.debugger.SetAsync(True) #needed so XCode doesn't hang if tap on Continue while lldb is waiting for user input in 'vs' mode
     while self.keepRunning:
-      charRead = sys.stdin.readline().rstrip("\n") #removes /n char added by readLine
+      charRead = sys.stdin.readline().rstrip("\n")
       self.inputCallback(charRead)
+    else:
+      lldb.debugger.SetAsync(initialAsync) #restore to init value
 
   def inputCallback(self, input):
     oldView = self.currentView
@@ -114,9 +117,7 @@ class FlickerWalker:
     else:
       print '\nChisel - VS Mode: I really have no idea what you meant by \'' + input + '\'... =\\\n'
 
-    viewHelpers.setViewHidden(oldView, False)
-
-  def setCurrentView(self, view, oldView):
+  def setCurrentView(self, view, oldView=None):
     if view:
       self.currentView = view
       if oldView:


### PR DESCRIPTION
Fixed ‘vs’ command by (Issue https://github.com/facebook/chisel/issues/88#issuecomment-98440239):

- Stop using FBInputHandler. This class uses SBInputReader which no
longer exist in the lldb version that comes bundled with XCode (that’s
why the command was broken), even tho it does exist in the official
lldb documentation
(http://lldb.llvm.org/python_reference/lldb.SBInputReader-class.html).

- Now the script uses the standard stdin library to read from terminal.

- Removed the ‘Flickering’ of the selected view, instead we now use
mask which is a lot more useful visually.

NOTE: As mentioned this fix doesn't use the class FBInputHandler at all to avoid SBInputReader, but if we have that class back in next versions of XCode we can always revert this fix-commit. 