### PR TITLE
Add `pactions` command to print the target/actions of a UIControl

### DIFF
--- a/commands/FBPrintCommands.py
+++ b/commands/FBPrintCommands.py
@@ -394,6 +394,6 @@ class FBPrintTargetActions(fb.FBCommand):
       actions = fb.evaluateObjectExpression('[{control} actionsForTarget:{target} forControlEvent:0]'.format(control=control, target=target))
 
       targetDescription = fb.evaluateExpressionValue('(id){target}'.format(target=target)).GetObjectDescription()
-      actionsDescription = fb.evaluateExpressionValue('(id)[{actions} componentsJoinedByString:@","]'.format(actions=actions)).GetObjectDescription()
+      actionsDescription = fb.evaluateExpressionValue('(id)[{actions} componentsJoinedByString:@", "]'.format(actions=actions)).GetObjectDescription()
 
       print '{target}: {actions}'.format(target=targetDescription, actions=actionsDescription)


### PR DESCRIPTION
I've been meaning to add a `pactions` command for a while. It's pretty basic. It would be nice to print out which control event the action observes, but this covers probably 90+% of the cases. In #59, I mentioned it might be nice to have a `bactions` command too, but I'm thinking that's a wait and see enhancement.

For a view controller, an example of the output is:

`<XXXViewController: 0xdddddddd>: didTapButton:`

and if there are multiple actions:

`<XXXViewController: 0xdddddddd>: didTapButton:, didTouchButton:`

cc @arigrant 