### PR TITLE
Exception fixes in functionPreambleExpression*

### DIFF
--- a/fblldbobjcruntimehelpers.py
+++ b/fblldbobjcruntimehelpers.py
@@ -66,7 +66,7 @@ def functionPreambleExpressionForObjectParameterAtIndex(parameterIndex):
     expresssion = '*(id*)($esp + ' + str(12 + parameterIndex * 4) + ')'
   elif arch == 'x86_64':
     if parameterIndex > 3:
-      raise Exception("Current implementation can not return object at index greater than 3 for arc x86_64")
+      raise Exception("Current implementation can not return object at index greater than 3 for x86_64")
     registersList = ['rdx', 'rcx', 'r8', 'r9']
     expresssion = '(id)$' + registersList[parameterIndex]
   elif arch == 'arm64':
@@ -74,7 +74,7 @@ def functionPreambleExpressionForObjectParameterAtIndex(parameterIndex):
       raise Exception("Current implementation can not return object at index greater than 5 for arm64")
     expresssion = '(id)$x' + str(parameterIndex + 2)
   elif re.match(r'^armv.*$', arch):
-    if parameterIndex > 3:
+    if parameterIndex > 1:
       raise Exception("Current implementation can not return object at index greater than 1 for arm32")
     expresssion = '(id)$r' + str(parameterIndex + 2)
   return expresssion


### PR DESCRIPTION
Minor fixes in `functionPreambleExpressionForObjectParameterAtIndex`. Fixes an exception message for x86-64, and an exception condition for arm32.