### PR TITLE
Prevent overly eager regex match in `fv` command

### DIFF
--- a/commands/FBFindCommands.py
+++ b/commands/FBFindCommands.py
@@ -93,7 +93,7 @@ class FBFindViewCommand(fb.FBCommand):
 
 def printMatchesInViewOutputStringAndCopyFirstToClipboard(needle, haystack):
   first = None
-  for match in re.finditer('.*<.*(' + needle + ').*: (0x[0-9a-fA-F]*);.*', haystack, re.IGNORECASE):
+  for match in re.finditer('.*<.*(' + needle + ')\\S*: (0x[0-9a-fA-F]*);.*', haystack, re.IGNORECASE):
     view = match.groups()[-1]
     className = fb.evaluateExpressionValue('(id)[(' + view + ') class]').GetObjectDescription()
     print('{} {}'.format(view, className))


### PR DESCRIPTION
The regex used in `fv` is overly eager about how it matches the class name. This change replaces a `.*` with `\S*`. Without this, a formatted object embedded in a view's description could be matched as the address of the view. For example:

`<ABCOneTwoThreeView: 0x25f9f180; frame = (12 606; 401 401); image = <UIImage: 0x215e9a80; …>>`

Previously, the `fv` command would match the second address (`0x215e9a80`). This change will capture the first address in this case.