### PR TITLE
Add ability to visualize UIColor, CIColor, and CGColorRef.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,7 @@ possible.
 
 ## Pull Requests
 We actively welcome your pull requests.
+
 1. Fork the repo and create your branch from `master`. 
 2. If you've added code that should be tested, add tests
 3. If you've changed APIs, update the documentation. 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ For a comprehensive overview of LLDB, and how Chisel complements it, read Ari Gr
 
 ## Installation
 
-```
+```shell
 brew update
 brew install chisel
 ```
@@ -79,7 +79,7 @@ All of the commands provided by `Chisel` come with verbose help. Be sure to read
 ## Custom Commands
 You can add local, custom commands. Here's a contrived example.
 
-```
+```python
 #!/usr/bin/python
 # Example file with custom commands, located at /magical/commands/example.py
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Developing commands, whether for local use or contributing to `Chisel` directly,
 
 1. Start `LLDB`
 2. Reach a breakpoint (or simply pause execution via the pause button in `Xcode`'s debug bar or `process interrupt` if attached directly)
-3. Execute _command source ~/.lldbinit_ in `LLDB` to source the commands
+3. Execute `command source ~/.lldbinit` in LLDB to source the commands
 4. Run the command you are working on
 5. Modify the command
 6. Optionally run `script reload(modulename)`

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ There are many commands; here's a few:
 |-----------------|----------------|-------|-------|
 |pviews           |Print the recursive view description for the key window.|Yes|Yes|
 |pvc              |Print the recursive view controller description for the key window.|Yes|No|
-|visualize        |Open a UIImage, CGImageRef, UIView, or CALayer in Preview.app on your Mac.|Yes|No|
+|visualize        |Open a `UIImage`, `CGImageRef`, `UIView`, `CALayer`, `NSData` (of an image), `UIColor`, `CIColor`, or `CGColorRef` in Preview.app on your Mac.|Yes|No|
 |fv               |Find a view in the hierarchy whose class name matches the provided regex.|Yes|No|
 |fvc              |Find a view controller in the hierarchy whose class name matches the provided regex.|Yes|No|
 |show/hide        |Show or hide the given view or layer. You don't even have to continue the process to see the changes!|Yes|Yes|

--- a/commands/FBVisualizationCommands.py
+++ b/commands/FBVisualizationCommands.py
@@ -65,13 +65,10 @@ def _colorIsCGColorRef(color):
 
   if result.GetError() is not None and str(result.GetError()) != 'success':
     print "got error: {}".format(result)
-    return 0
+    return False
   else:
     isCFColor = result.GetValueAsUnsigned() != 0
-    if isCFColor:
-      return 1
-    else:
-      return 0
+    return isCFColor
 
 def _showColor(color):
     color = '(' + color + ')'
@@ -124,13 +121,10 @@ def _dataIsImage(data):
   result = frame.EvaluateExpression('(id)[UIImage imageWithData:' + data + ']')
 
   if result.GetError() is not None and str(result.GetError()) != 'success':
-    return 0
+    return False
   else:
     isImage = result.GetValueAsUnsigned() != 0
-    if isImage:
-      return 1
-    else:
-      return 0
+    return isImage
 
 def _dataIsString(data):
   data = '(' + data + ')'
@@ -139,13 +133,10 @@ def _dataIsString(data):
   result = frame.EvaluateExpression('(NSString*)[[NSString alloc] initWithData:' + data + ' encoding:4]')
 
   if result.GetError() is not None and str(result.GetError()) != 'success':
-    return 0
+    return False
   else:
     isString = result.GetValueAsUnsigned() != 0
-    if isString:
-      return 1
-    else:
-      return 0
+    return isString
 
 def _visualize(target):
   target = '(' + target + ')'


### PR DESCRIPTION
Looks like this:

![screen shot 2015-08-04 at 9 57 14 am](https://cloud.githubusercontent.com/assets/464574/9062287/6a8b5f54-3a8f-11e5-9276-adc85866ff34.png)

We could add more fancy visualization, including rendering text of what the constituent colors are, like Apple does, but I figured it would be a good idea to start simple.

Fixes #103 