### PR TITLE
pcurl command

### DIFF
--- a/commands/FBPrintCommands.py
+++ b/commands/FBPrintCommands.py
@@ -32,10 +32,7 @@ def lldbcommands():
     FBPrintApplicationDocumentsPath(),
     FBPrintData(),
     FBPrintTargetActions(),
-<<<<<<< HEAD
     FBPrintJSON(),
-=======
->>>>>>> origin/pcurl
     FBPrintAsCurl(),
   ]
 
@@ -430,7 +427,6 @@ class FBPrintTargetActions(fb.FBCommand):
 
       print '{target}: {actions}'.format(target=targetDescription, actions=actionsDescription)
 
-<<<<<<< HEAD
 class FBPrintJSON(fb.FBCommand):
     
   def name(self):
@@ -455,8 +451,6 @@ class FBPrintJSON(fb.FBCommand):
     
     print jsonString
     
-=======
->>>>>>> origin/pcurl
 class FBPrintAsCurl(fb.FBCommand):
   def name(self):
     return 'pcurl'

--- a/commands/FBPrintCommands.py
+++ b/commands/FBPrintCommands.py
@@ -460,7 +460,7 @@ class FBPrintAsCurl(fb.FBCommand):
 
   def options(self):
     return [
-      fb.FBCommandArgument(short='-p', long='--portable', arg='portable', boolean=True, default=False, help='Embed request data as base64.'),
+      fb.FBCommandArgument(short='-e', long='--embed-data', arg='embed', boolean=True, default=False, help='Embed request data as base64.'),
     ]
 
   def args(self):
@@ -487,7 +487,7 @@ class FBPrintAsCurl(fb.FBCommand):
     dataAsString = None
     if fb.evaluateIntegerExpression('[{} length]'.format(HTTPData)) > 0:
         dataFile = '/tmp/curl_data_{}'.format(fb.evaluateExpression('(NSTimeInterval)[NSDate timeIntervalSinceReferenceDate]'))
-        if options.portable:
+        if options.embed:
           if fb.evaluateIntegerExpression('[{} respondsToSelector:@selector(base64EncodedStringWithOptions:)]'.format(HTTPData)):
             dataAsString = fb.evaluateExpressionValue('(id)[(id){} base64EncodedStringWithOptions:0]'.format(HTTPData)).GetObjectDescription()
         elif not runtimeHelpers.isIOSDevice():

--- a/commands/FBPrintCommands.py
+++ b/commands/FBPrintCommands.py
@@ -493,12 +493,12 @@ class FBPrintAsCurl(fb.FBCommand):
         elif not runtimeHelpers.isIOSDevice():
           fb.evaluateExpression('(BOOL)[{} writeToFile:@"{}" atomically:NO]'.format(HTTPData, dataFile))
         else:
-          print 'HTTPBody data for iOS Device is supported only with "--portable" flag'
+          print 'HTTPBody data for iOS Device is supported only with "--embed-data" flag'
           return False
 
     commandString = ''
     if dataAsString is not None and len(dataAsString) > 0:
-      commandString += 'echo "{}" | base64 -D -o "{}"; '.format(dataAsString, dataFile)
+      commandString += 'echo "{}" | base64 -D -o "{}" && '.format(dataAsString, dataFile)
     commandString += 'curl -X {} --connect-timeout {}'.format(HTTPMethod, timeout)
     if len(HTTPHeaderSring) > 0:
         commandString += ' ' + HTTPHeaderSring

--- a/commands/FBPrintCommands.py
+++ b/commands/FBPrintCommands.py
@@ -33,6 +33,7 @@ def lldbcommands():
     FBPrintData(),
     FBPrintTargetActions(),
     FBPrintJSON(),
+    FBPrintAsCurl(),
   ]
 
 class FBPrintViewHierarchyCommand(fb.FBCommand):
@@ -450,3 +451,43 @@ class FBPrintJSON(fb.FBCommand):
     
     print jsonString
     
+class FBPrintAsCurl(fb.FBCommand):
+  def name(self):
+    return 'pcurl'
+
+  def description(self):
+    return 'Print the NSURLRequest (HTTP) as curl command.'
+
+  def args(self):
+    return [ fb.FBCommandArgument(arg='request', type='NSURLRequest*/NSMutableURLRequest*', help='The request to convert to the curl command.') ]
+
+  def run(self, arguments, options):
+    request = arguments[0]
+    HTTPHeaderSring = ''
+    HTTPMethod = fb.evaluateExpressionValue('(id)[{request} HTTPMethod]'.format(request=request)).GetObjectDescription()
+    URL = fb.evaluateExpressionValue('(id)[{request} URL]'.format(request=request)).GetObjectDescription()
+    timeout = fb.evaluateExpression('(NSTimeInterval)[{request} timeoutInterval]'.format(request=request))
+    HTTPHeaders = fb.evaluateObjectExpression('(id)[{request} allHTTPHeaderFields]'.format(request=request))
+    HTTPHeadersCount = fb.evaluateIntegerExpression('[{HTTPHeaders} count]'.format(HTTPHeaders=HTTPHeaders)) 
+    allHTTPKeys = fb.evaluateObjectExpression('[{HTTPHeaders} allKeys]'.format(HTTPHeaders=HTTPHeaders))
+    for index in range(0, HTTPHeadersCount):
+        key = fb.evaluateObjectExpression('[{} objectAtIndex:{}]'.format(allHTTPKeys, index))
+        keyDescription = fb.evaluateExpressionValue('(id){}'.format(key)).GetObjectDescription()
+        value = fb.evaluateExpressionValue('(id)[(id){} objectForKey:{}]'.format(HTTPHeaders, key)).GetObjectDescription()
+        if len(HTTPHeaderSring) > 0:
+            HTTPHeaderSring += ' '
+        HTTPHeaderSring += '-H "{}: {}"'.format(keyDescription, value)
+    HTTPData = fb.evaluateObjectExpression('[{request} HTTPBody]'.format(request=request))
+    dataFile = None
+    if fb.evaluateIntegerExpression('[{} length]'.format(HTTPData)) > 0:
+        dataFile = '/tmp/curl_data_{}'.format(fb.evaluateExpression('(NSTimeInterval)[NSDate timeIntervalSinceReferenceDate]'))
+        fb.evaluateExpression('(BOOL)[{} writeToFile:@"{}" atomically:NO]'.format(HTTPData, dataFile))
+                
+    commandString = 'curl -X {} --connect-timeout {}'.format(HTTPMethod, timeout)
+    if len(HTTPHeaderSring) > 0:
+        commandString += ' ' + HTTPHeaderSring
+    if dataFile is not None:
+        commandString += ' --data-binary @"{}"'.format(dataFile)
+        
+    commandString += ' "{}"'.format(URL)
+    print commandString

--- a/fblldbobjcruntimehelpers.py
+++ b/fblldbobjcruntimehelpers.py
@@ -88,3 +88,9 @@ def isMacintoshArch():
   command = '(void*)objc_getClass("{}")'.format(nsClassName)
 
   return (fb.evaluateBooleanExpression(command + '!= nil'))
+
+def isIOSSimulator():
+  return fb.evaluateExpressionValue('(id)[[UIDevice currentDevice] model]').GetObjectDescription().lower().find('simulator') >= 0
+
+def isIOSDevice():
+  return not isMacintoshArch() and not isIOSSimulator()


### PR DESCRIPTION
Added ability to convert NSURLReuqest to curl command.
Example:
```Objective-C
  NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:[NSURL URLWithString:@"https://google.com"]];
  request.timeoutInterval = 30;
  request.HTTPMethod = @"POST";
  request.allHTTPHeaderFields = @{@"Header1" : @"test-1", @"Header2" : @"some test sttring"};
  request.HTTPBody = [@"sample data" dataUsingEncoding:NSUTF8StringEncoding];
```
```
curl -X POST --connect-timeout 30 -H "Header2: some test sttring" -H "Header1: test-1" --data-binary @"/tmp/curl_data_463408775.11118102" "https://google.com"
```
Also you can embed data into terminal command with --embed-data parameter, result:
```
echo "c2FtcGxlIGRhdGE=" | base64 -D -o "/tmp/curl_data_463487823.35579801"; curl -X POST --connect-timeout 30 -H "Header2: some test sttring" -H "Header1: test-1" --data-binary @"/tmp/curl_data_463487823.35579801" "https://google.com"
```