### PR TITLE
Use base10 value for ivarOffset to be consistent with other values used

### DIFF
--- a/commands/FBDebugCommands.py
+++ b/commands/FBDebugCommands.py
@@ -32,7 +32,7 @@ class FBWatchInstanceVariableCommand(fb.FBCommand):
     objectAddress = int(fb.evaluateObjectExpression(commandForObject), 0)
 
     ivarOffsetCommand = '(ptrdiff_t)ivar_getOffset((void*)object_getInstanceVariable((id){}, "{}", 0))'.format(objectAddress, ivarName)
-    ivarOffset = fb.evaluateIntegerExpression(ivarOffsetCommand)
+    ivarOffset = int(fb.evaluateExpression(ivarOffsetCommand), 0)
 
     # A multi-statement command allows for variables scoped to the command, not permanent in the session like $variables.
     ivarSizeCommand = ('unsigned int size = 0;'


### PR DESCRIPTION
in calculating memory address of watchpoint.

When running this line `    watchpoint = lldb.debugger.GetSelectedTarget().WatchAddress(objectAddress + ivarOffset, ivarSize, False, True, error)`

`objectAddress` and `ivarSize` are in base10, while `ivarOffset` is in hex after returning from `fb.evaluateIntegerExpression`.

This fixes that issue and now the memory address of the watchpoint is being set correctly.