### PR TITLE
Get Swifty - Update everything to use ObjC++ or Swift contexts explicitly

### DIFF
--- a/commands/FBAccessibilityCommands.py
+++ b/commands/FBAccessibilityCommands.py
@@ -78,9 +78,9 @@ def forceStartAccessibilityServer():
   if not fb.evaluateBooleanExpression('[UIView instancesRespondToSelector:@selector(_accessibilityElementsInContainer:)]'):
     #Starting accessibility server is different for simulator and device
     if fb.evaluateExpressionValue('(id)[[UIDevice currentDevice] model]').GetObjectDescription().lower().find('simulator') >= 0:
-      lldb.debugger.HandleCommand('expr (void)[[UIApplication sharedApplication] accessibilityActivate]')
+      lldb.debugger.HandleCommand('eobjc (void)[[UIApplication sharedApplication] accessibilityActivate]')
     else:
-      lldb.debugger.HandleCommand('expr (void)[[[UIApplication sharedApplication] _accessibilityBundlePrincipalClass] _accessibilityStartServer]')
+      lldb.debugger.HandleCommand('eobjc (void)[[[UIApplication sharedApplication] _accessibilityBundlePrincipalClass] _accessibilityStartServer]')
 
 def accessibilityLabel(view):
   #using Apple private API to get real value of accessibility string for element.

--- a/commands/FBAutoLayoutCommands.py
+++ b/commands/FBAutoLayoutCommands.py
@@ -40,8 +40,8 @@ def setBorderOnAmbiguousViewRecursive(view, width, color):
   isAmbiguous = fb.evaluateBooleanExpression('(BOOL)[%s hasAmbiguousLayout]' % view)
   if isAmbiguous:
     layer = viewHelpers.convertToLayer(view)
-    lldb.debugger.HandleCommand('expr (void)[%s setBorderWidth:(CGFloat)%s]' % (layer, width))
-    lldb.debugger.HandleCommand('expr (void)[%s setBorderColor:(CGColorRef)[(id)[UIColor %sColor] CGColor]]' % (layer, color))
+    lldb.debugger.HandleCommand('eobjc (void)[%s setBorderWidth:(CGFloat)%s]' % (layer, width))
+    lldb.debugger.HandleCommand('eobjc (void)[%s setBorderColor:(CGColorRef)[(id)[UIColor %sColor] CGColor]]' % (layer, color))
 
   subviews = fb.evaluateExpression('(id)[%s subviews]' % view)
   subviewsCount = int(fb.evaluateExpression('(int)[(id)%s count]' % subviews))

--- a/commands/FBAutoLayoutCommands.py
+++ b/commands/FBAutoLayoutCommands.py
@@ -30,7 +30,7 @@ class FBPrintAutolayoutTrace(fb.FBCommand):
     return [ fb.FBCommandArgument(arg='view', type='UIView *', help='The view to print the Auto Layout trace for.', default='(id)[[UIApplication sharedApplication] keyWindow]') ]
 
   def run(self, arguments, options):
-    lldb.debugger.HandleCommand('po (id)[{} _autolayoutTrace]'.format(arguments[0]))
+    lldb.debugger.HandleCommand('poobjc (id)[{} _autolayoutTrace]'.format(arguments[0]))
 
 
 def setBorderOnAmbiguousViewRecursive(view, width, color):

--- a/commands/FBComponentCommands.py
+++ b/commands/FBComponentCommands.py
@@ -60,7 +60,7 @@ class FBComponentsPrintCommand(fb.FBCommand):
     upwards = 'YES' if options.upwards else 'NO'
     showViews = 'YES' if options.showViews == 'YES' else 'NO'
 
-    lldb.debugger.HandleCommand('po (id)[CKComponentHierarchyDebugHelper componentHierarchyDescriptionForView:(UIView *)' + arguments[0] + ' searchUpwards:' + upwards + ' showViews:' + showViews + ']')
+    lldb.debugger.HandleCommand('poobjc (id)[CKComponentHierarchyDebugHelper componentHierarchyDescriptionForView:(UIView *)' + arguments[0] + ' searchUpwards:' + upwards + ' showViews:' + showViews + ']')
 
 class FBComponentsReflowCommand(fb.FBCommand):
   def name(self):

--- a/commands/FBComponentCommands.py
+++ b/commands/FBComponentCommands.py
@@ -32,10 +32,10 @@ class FBComponentsDebugCommand(fb.FBCommand):
 
   def run(self, arguments, options):
     if options.set:
-      lldb.debugger.HandleCommand('expr (void)[CKComponentDebugController setDebugMode:YES]')
+      lldb.debugger.HandleCommand('eobjc (void)[CKComponentDebugController setDebugMode:YES]')
       print 'Debug mode for ComponentKit has been set.'
     elif options.unset:
-      lldb.debugger.HandleCommand('expr (void)[CKComponentDebugController setDebugMode:NO]')
+      lldb.debugger.HandleCommand('eobjc (void)[CKComponentDebugController setDebugMode:NO]')
       print 'Debug mode for ComponentKit has been unset.'
     else:
       print 'No option for ComponentKit Debug mode specified.'

--- a/commands/FBDisplayCommands.py
+++ b/commands/FBDisplayCommands.py
@@ -60,8 +60,8 @@ class FBDrawBorderCommand(fb.FBCommand):
 
   def run(self, args, options):
     def setBorder(layer, width, color, colorClass):
-      lldb.debugger.HandleCommand('expr (void)[%s setBorderWidth:(CGFloat)%s]' % (layer, width))
-      lldb.debugger.HandleCommand('expr (void)[%s setBorderColor:(CGColorRef)[(id)[%s %sColor] CGColor]]' % (layer, colorClass, color))
+      lldb.debugger.HandleCommand('eobjc (void)[%s setBorderWidth:(CGFloat)%s]' % (layer, width))
+      lldb.debugger.HandleCommand('eobjc (void)[%s setBorderColor:(CGColorRef)[(id)[%s %sColor] CGColor]]' % (layer, colorClass, color))
 
     obj = args[0]
     depth = int(options.depth)
@@ -111,7 +111,7 @@ class FBRemoveBorderCommand(fb.FBCommand):
 
   def run(self, args, options):
     def setUnborder(layer):
-        lldb.debugger.HandleCommand('expr (void)[%s setBorderWidth:(CGFloat)%s]' % (layer, 0))
+        lldb.debugger.HandleCommand('eobjc (void)[%s setBorderWidth:(CGFloat)%s]' % (layer, 0))
 
     obj = args[0]
     depth = int(options.depth)

--- a/commands/FBFindCommands.py
+++ b/commands/FBFindCommands.py
@@ -122,6 +122,6 @@ class FBTapLoggerCommand(fb.FBCommand):
   @staticmethod
   def taplog_callback(frame, bp_loc, internal_dict):
     parameterExpr = objc.functionPreambleExpressionForObjectParameterAtIndex(0)
-    lldb.debugger.HandleCommand('po [[[%s allTouches] anyObject] view]' % (parameterExpr))
+    lldb.debugger.HandleCommand('poobjc (UIView *)[[[%s allTouches] anyObject] view]' % (parameterExpr))
     # We don't want to proceed event (click on button for example), so we just skip it
     lldb.debugger.HandleCommand('thread return')

--- a/commands/FBFlickerCommands.py
+++ b/commands/FBFlickerCommands.py
@@ -111,7 +111,7 @@ class FlickerWalker:
       if isMac:
         recursionName = '_subtreeDescription'
 
-      lldb.debugger.HandleCommand('po [(id)' + oldView + ' ' + recusionName + ']')
+      lldb.debugger.HandleCommand('poobjc (NSString *)[(id)' + oldView + ' ' + recusionName + ']')
     else:
       print '\nI really have no idea what you meant by \'' + input + '\'... =\\\n'
 
@@ -121,7 +121,7 @@ class FlickerWalker:
       if oldView:
         viewHelpers.unmaskView(oldView)
       viewHelpers.maskView(self.currentView, 'red', '0.4')
-      lldb.debugger.HandleCommand('po (id)' + view)
+      lldb.debugger.HandleCommand('poobjc (id)' + view)
 
 def superviewOfView(view):
   superview = fb.evaluateObjectExpression('[' + view + ' superview]')

--- a/commands/FBInvocationCommands.py
+++ b/commands/FBInvocationCommands.py
@@ -114,8 +114,8 @@ def prettyPrintInvocation(frame, invocation):
     for argDescription in argDescriptions:
       s = re.sub(r'argument [0-9]+: ', '', argDescription)
 
-      lldb.debugger.HandleCommand('expr void *$v')
-      lldb.debugger.HandleCommand('expr (void)[' + invocation + ' getArgument:&$v atIndex:' + str(index) + ']')
+      lldb.debugger.HandleCommand('eobjc void *$v')
+      lldb.debugger.HandleCommand('eobjc (void)[' + invocation + ' getArgument:&$v atIndex:' + str(index) + ']')
 
       address = findArgAdressAtIndexFromStackFrame(frame, index)
 

--- a/commands/FBPrintCommands.py
+++ b/commands/FBPrintCommands.py
@@ -95,7 +95,7 @@ class FBPrintCoreAnimationTree(fb.FBCommand):
     return 'Print layer tree from the perspective of the render server.'
 
   def run(self, arguments, options):
-    lldb.debugger.HandleCommand('po [NSString stringWithCString:(char *)CARenderServerGetInfo(0, 2, 0)]')
+    lldb.debugger.HandleCommand('poobjc (NSString *)[NSString stringWithCString:(char *)CARenderServerGetInfo(0, 2, 0)]')
 
 
 class FBPrintViewControllerHierarchyCommand(fb.FBCommand):
@@ -113,7 +113,7 @@ class FBPrintViewControllerHierarchyCommand(fb.FBCommand):
 
     if arguments[0] == '__keyWindow_rootVC_dynamic__':
       if fb.evaluateBooleanExpression('[UIViewController respondsToSelector:@selector(_printHierarchy)]'):
-        lldb.debugger.HandleCommand('po [UIViewController _printHierarchy]')
+        lldb.debugger.HandleCommand('poobjc (NSString *)[UIViewController _printHierarchy]')
         return
 
       arguments[0] = '(id)[(id)[[UIApplication sharedApplication] keyWindow] rootViewController]'
@@ -284,7 +284,7 @@ class FBPrintInstanceVariable(fb.FBCommand):
     ivarTypeCommand = '((char *)ivar_getTypeEncoding((void*)object_getInstanceVariable((id){}, \"{}\", 0)))[0]'.format(object, ivarName)
     ivarTypeEncodingFirstChar = fb.evaluateExpression(ivarTypeCommand)
 
-    printCommand = 'po' if ('@' in ivarTypeEncodingFirstChar) else 'p'
+    printCommand = 'poobjc' if ('@' in ivarTypeEncodingFirstChar) else 'pobjc'
     lldb.debugger.HandleCommand('{} (({} *)({}))->{}'.format(printCommand, objectClass, object, ivarName))
 
 class FBPrintKeyPath(fb.FBCommand):
@@ -306,7 +306,7 @@ class FBPrintKeyPath(fb.FBCommand):
     else:
       objectToMessage, keypath = command.split('.', 1)
       object = fb.evaluateObjectExpression(objectToMessage)
-      printCommand = 'po [{} valueForKeyPath:@"{}"]'.format(object, keypath)
+      printCommand = 'poobjc (id)[{} valueForKeyPath:@"{}"]'.format(object, keypath)
       lldb.debugger.HandleCommand(printCommand)
 
 
@@ -403,7 +403,7 @@ class FBPrintData(fb.FBCommand):
     elif encoding_text == 'utf32l':
       enc = 0x9c000100
 
-    print_command = 'po (NSString *)[[NSString alloc] initWithData:{} encoding:{}]'.format(arguments[0], enc)
+    print_command = 'poobjc (NSString *)[[NSString alloc] initWithData:{} encoding:{}]'.format(arguments[0], enc)
     lldb.debugger.HandleCommand(print_command)
 
 class FBPrintTargetActions(fb.FBCommand):

--- a/commands/FBPrintCommands.py
+++ b/commands/FBPrintCommands.py
@@ -36,6 +36,8 @@ def lldbcommands():
     FBPrintAsCurl(),
     FBPrintInObjc(),
     FBPrintInSwift(),
+    FBPrintObjectInObjc(),
+    FBPrintObjectInSwift(),
   ]
 
 class FBPrintViewHierarchyCommand(fb.FBCommand):
@@ -550,3 +552,35 @@ class FBPrintInSwift(fb.FBCommand):
   def run(self, arguments, options):
     expression = arguments[0]
     lldb.debugger.HandleCommand('expression -l Swift -- ' + expression)
+
+class FBPrintObjectInObjc(fb.FBCommand):
+  def name(self):
+    return 'poobjc'
+
+  def description(self):
+    return 'Print the expression result, with the expression run in an ObjC++ context. (Shortcut for "expression -O -l ObjC++ -- " )'
+
+  def args(self):
+    return [
+      fb.FBCommandArgument(arg='expression', help='ObjC expression to evaluate and print.'),
+    ]
+
+  def run(self, arguments, options):
+    expression = arguments[0]
+    lldb.debugger.HandleCommand('expression -O -l ObjC++ -- ' + expression)
+
+class FBPrintObjectInSwift(fb.FBCommand):
+  def name(self):
+    return 'poswift'
+
+  def description(self):
+    return 'Print the expression result, with the expression run in a Swift context. (Shortcut for "expression -O -l Swift -- " )'
+
+  def args(self):
+    return [
+      fb.FBCommandArgument(arg='expression', help='Swift expression to evaluate and print.'),
+    ]
+
+  def run(self, arguments, options):
+    expression = arguments[0]
+    lldb.debugger.HandleCommand('expression -O -l Swift -- ' + expression)

--- a/commands/FBPrintCommands.py
+++ b/commands/FBPrintCommands.py
@@ -38,6 +38,8 @@ def lldbcommands():
     FBPrintInSwift(),
     FBPrintObjectInObjc(),
     FBPrintObjectInSwift(),
+    FBExpressionInObjc(),
+    FBExpressionInSwift(),
   ]
 
 class FBPrintViewHierarchyCommand(fb.FBCommand):
@@ -584,3 +586,45 @@ class FBPrintObjectInSwift(fb.FBCommand):
   def run(self, arguments, options):
     expression = arguments[0]
     lldb.debugger.HandleCommand('expression -O -l Swift -- ' + expression)
+
+class FBExpressionInObjc(fb.FBCommand):
+  def name(self):
+    return 'eobjc'
+
+  def description(self):
+    return 'Run expression run in an ObjC++ context. (Shortcut for "expression -l ObjC++" )'
+
+  def args(self):
+    return [
+      fb.FBCommandArgument(arg='expression', help='ObjC expression to evaluate and print.'),
+    ]
+
+  def run(self, arguments, options):
+    values = arguments[0].split("--", 1)
+    if len(values) is 2:
+        (arguments, expression) = arguments
+        lldb.debugger.HandleCommand('expression -l ObjC++ ' + arguments + " -- " + expression)
+    else:
+        expression = arguments[0]
+        lldb.debugger.HandleCommand('expression -l ObjC++ -- ' + expression)
+
+class FBExpressionInSwift(fb.FBCommand):
+  def name(self):
+    return 'eswift'
+
+  def description(self):
+    return 'Run expression run in a Swift context. (Shortcut for "expression -l Swift" )'
+
+  def args(self):
+    return [
+      fb.FBCommandArgument(arg='expression', help='Swift expression to evaluate and print.'),
+    ]
+
+  def run(self, arguments, options):
+    values = arguments[0].split("--", 1)
+    if len(values) is 2:
+        (arguments, expression) = arguments
+        lldb.debugger.HandleCommand('expression -l Swift ' + arguments + " -- " + expression)
+    else:
+        expression = arguments[0]
+        lldb.debugger.HandleCommand('expression -l Swift -- ' + expression)

--- a/commands/FBPrintCommands.py
+++ b/commands/FBPrintCommands.py
@@ -34,6 +34,8 @@ def lldbcommands():
     FBPrintTargetActions(),
     FBPrintJSON(),
     FBPrintAsCurl(),
+    FBPrintInObjc(),
+    FBPrintInSwift(),
   ]
 
 class FBPrintViewHierarchyCommand(fb.FBCommand):
@@ -516,3 +518,35 @@ class FBPrintAsCurl(fb.FBCommand):
         
     commandString += ' "{}"'.format(URL)
     print commandString
+
+class FBPrintInObjc(fb.FBCommand):
+  def name(self):
+    return 'pobjc'
+
+  def description(self):
+    return 'Print the expression result, with the expression run in an ObjC++ context. (Shortcut for "expression -l ObjC++ -- " )'
+
+  def args(self):
+    return [
+      fb.FBCommandArgument(arg='expression', help='ObjC expression to evaluate and print.'),
+    ]
+
+  def run(self, arguments, options):
+    expression = arguments[0]
+    lldb.debugger.HandleCommand('expression -l ObjC++ -- ' + expression)
+
+class FBPrintInSwift(fb.FBCommand):
+  def name(self):
+    return 'pswift'
+
+  def description(self):
+    return 'Print the expression result, with the expression run in a Swift context. (Shortcut for "expression -l Swift -- " )'
+
+  def args(self):
+    return [
+      fb.FBCommandArgument(arg='expression', help='Swift expression to evaluate and print.'),
+    ]
+
+  def run(self, arguments, options):
+    expression = arguments[0]
+    lldb.debugger.HandleCommand('expression -l Swift -- ' + expression)

--- a/commands/FBVisualizationCommands.py
+++ b/commands/FBVisualizationCommands.py
@@ -83,9 +83,9 @@ def _showColor(color):
         colorToUse = '[UIColor colorWithCIColor:(CIColor *){}]'.format(color)
 
     imageSize = 58
-    lldb.debugger.HandleCommand('expr (void)UIGraphicsBeginImageContextWithOptions((CGSize)CGSizeMake({imageSize}, {imageSize}), NO, 0.0)'.format(imageSize=imageSize))
-    lldb.debugger.HandleCommand('expr (void)[(id){} setFill]'.format(colorToUse))
-    lldb.debugger.HandleCommand('expr (void)UIRectFill((CGRect)CGRectMake(0.0, 0.0, {imageSize}, {imageSize}))'.format(imageSize=imageSize))
+    lldb.debugger.HandleCommand('eobjc (void)UIGraphicsBeginImageContextWithOptions((CGSize)CGSizeMake({imageSize}, {imageSize}), NO, 0.0)'.format(imageSize=imageSize))
+    lldb.debugger.HandleCommand('eobjc (void)[(id){} setFill]'.format(colorToUse))
+    lldb.debugger.HandleCommand('eobjc (void)UIRectFill((CGRect)CGRectMake(0.0, 0.0, {imageSize}, {imageSize}))'.format(imageSize=imageSize))
 
     frame = lldb.debugger.GetSelectedTarget().GetProcess().GetSelectedThread().GetSelectedFrame()
     result = frame.EvaluateExpression('(UIImage *)UIGraphicsGetImageFromCurrentImageContext()')
@@ -96,7 +96,7 @@ def _showColor(color):
       image = result.GetValue()
       _showImage(image)
 
-    lldb.debugger.HandleCommand('expr (void)UIGraphicsEndImageContext()')
+    lldb.debugger.HandleCommand('eobjc (void)UIGraphicsEndImageContext()')
 
 def _showLayer(layer):
   layer = '(' + layer + ')'
@@ -108,8 +108,8 @@ def _showLayer(layer):
     print 'Nothing to see here - the size of this element is {} x {}.'.format(width, height)
     return
 
-  lldb.debugger.HandleCommand('expr (void)UIGraphicsBeginImageContextWithOptions(' + size + ', NO, 0.0)')
-  lldb.debugger.HandleCommand('expr (void)[(id)' + layer + ' renderInContext:(void *)UIGraphicsGetCurrentContext()]')
+  lldb.debugger.HandleCommand('eobjc (void)UIGraphicsBeginImageContextWithOptions(' + size + ', NO, 0.0)')
+  lldb.debugger.HandleCommand('eobjc (void)[(id)' + layer + ' renderInContext:(void *)UIGraphicsGetCurrentContext()]')
 
   frame = lldb.debugger.GetSelectedTarget().GetProcess().GetSelectedThread().GetSelectedFrame()
   result = frame.EvaluateExpression('(UIImage *)UIGraphicsGetImageFromCurrentImageContext()')
@@ -119,7 +119,7 @@ def _showLayer(layer):
     image = result.GetValue()
     _showImage(image)
 
-  lldb.debugger.HandleCommand('expr (void)UIGraphicsEndImageContext()')
+  lldb.debugger.HandleCommand('eobjc (void)UIGraphicsEndImageContext()')
 
 def _dataIsImage(data):
   data = '(' + data + ')'

--- a/commands/FBVisualizationCommands.py
+++ b/commands/FBVisualizationCommands.py
@@ -163,7 +163,7 @@ def _visualize(target):
       if _dataIsImage(target):
         _showImage('(id)[UIImage imageWithData:' + target + ']')
       elif _dataIsString(target):
-        lldb.debugger.HandleCommand('po (NSString*)[[NSString alloc] initWithData:' + target + ' encoding:4]')
+        lldb.debugger.HandleCommand('poobjc (NSString*)[[NSString alloc] initWithData:' + target + ' encoding:4]')
       else:
         print 'Data isn\'t an image and isn\'t a string.'
     else:

--- a/fblldbviewhelpers.py
+++ b/fblldbviewhelpers.py
@@ -13,10 +13,10 @@ import fblldbbase as fb
 import fblldbobjcruntimehelpers as runtimeHelpers
 
 def flushCoreAnimationTransaction():
-  lldb.debugger.HandleCommand('expr (void)[CATransaction flush]')
+  lldb.debugger.HandleCommand('eobjc (void)[CATransaction flush]')
 
 def setViewHidden(object, hidden):
-  lldb.debugger.HandleCommand('expr (void)[' + object + ' setHidden:' + str(int(hidden)) + ']')
+  lldb.debugger.HandleCommand('eobjc (void)[' + object + ' setHidden:' + str(int(hidden)) + ']')
   flushCoreAnimationTransaction()
 
 def maskView(viewOrLayer, color, alpha):
@@ -31,16 +31,16 @@ def maskView(viewOrLayer, color, alpha):
                                                size.GetChildMemberWithName('height').GetValue())
   mask = fb.evaluateExpression('(id)[[UIView alloc] initWithFrame:%s]' % rectExpr)
 
-  lldb.debugger.HandleCommand('expr (void)[%s setTag:(NSInteger)%s]' % (mask, viewOrLayer))
-  lldb.debugger.HandleCommand('expr (void)[%s setBackgroundColor:[UIColor %sColor]]' % (mask, color))
-  lldb.debugger.HandleCommand('expr (void)[%s setAlpha:(CGFloat)%s]' % (mask, alpha))
-  lldb.debugger.HandleCommand('expr (void)[%s addSubview:%s]' % (window, mask))
+  lldb.debugger.HandleCommand('eobjc (void)[%s setTag:(NSInteger)%s]' % (mask, viewOrLayer))
+  lldb.debugger.HandleCommand('eobjc (void)[%s setBackgroundColor:[UIColor %sColor]]' % (mask, color))
+  lldb.debugger.HandleCommand('eobjc (void)[%s setAlpha:(CGFloat)%s]' % (mask, alpha))
+  lldb.debugger.HandleCommand('eobjc (void)[%s addSubview:%s]' % (window, mask))
   flushCoreAnimationTransaction()
 
 def unmaskView(viewOrLayer):
   window = fb.evaluateExpression('(UIWindow *)[[UIApplication sharedApplication] keyWindow]')
   mask = fb.evaluateExpression('(UIView *)[%s viewWithTag:(NSInteger)%s]' % (window, viewOrLayer))
-  lldb.debugger.HandleCommand('expr (void)[%s removeFromSuperview]' % mask)
+  lldb.debugger.HandleCommand('eobjc (void)[%s removeFromSuperview]' % mask)
   flushCoreAnimationTransaction()
 
 def convertPoint(x, y, fromViewOrLayer, toViewOrLayer):
@@ -113,4 +113,4 @@ def upwardsRecursiveDescription(view, maxDepth=0):
   return builder
 
 def slowAnimation(speed=1):
-  lldb.debugger.HandleCommand('expr (void)[[[UIApplication sharedApplication] windows] setValue:@(%s) forKeyPath:@"layer.speed"]' % speed)
+  lldb.debugger.HandleCommand('eobjc (void)[[[UIApplication sharedApplication] windows] setValue:@(%s) forKeyPath:@"layer.speed"]' % speed)


### PR DESCRIPTION
Adding a `po`-like shortcuts to run `expression` in either a Swift (`pswift`) or ObjC++ (`pobjc`) context, rather than use the language of the current frame.  Currently if you're trying do do something like `po [UIViewController _printHierarchy]` and you're not in an ObjC frame, the expression won't parse/run. It's potentially useful if you're trying to re-use commands and you're potentially going to change between languages in the meantime. 

Mainly trying to fix commands like `pvc` that end up on the fast track to Failtown when run from a breakpoint in Swift code.