### PR TITLE
Better Handing of Integer Literals

### DIFF
--- a/commands/FBAccessibilityCommands.py
+++ b/commands/FBAccessibilityCommands.py
@@ -96,7 +96,7 @@ def printAccessibilityHierarchy(view, indent = 0):
     print indentString + ('{} {}'.format(classDesc, view))
     #We call private method that gives back all visible accessibility children for view
     accessibilityElements = fb.evaluateObjectExpression('[[[UIApplication sharedApplication] keyWindow] _accessibilityElementsInContainer:0 topLevel:%s includeKB:0]' % view)
-    accessibilityElementsCount = int(fb.evaluateExpression('(int)[%s count]' % accessibilityElements))
+    accessibilityElementsCount = fb.evaluateIntegerExpression('(int)[%s count]' % accessibilityElements)
     for index in range(0, accessibilityElementsCount):
       subview = fb.evaluateObjectExpression('[%s objectAtIndex:%i]' % (accessibilityElements, index))
       printAccessibilityHierarchy(subview, indent + 1)

--- a/commands/FBAutoLayoutCommands.py
+++ b/commands/FBAutoLayoutCommands.py
@@ -44,7 +44,7 @@ def setBorderOnAmbiguousViewRecursive(view, width, color):
     lldb.debugger.HandleCommand('expr (void)[%s setBorderColor:(CGColorRef)[(id)[UIColor %sColor] CGColor]]' % (layer, color))
 
   subviews = fb.evaluateExpression('(id)[%s subviews]' % view)
-  subviewsCount = int(fb.evaluateExpression('(int)[(id)%s count]' % subviews))
+  subviewsCount = fb.evaluateIntegerExpression('(int)[(id)%s count]' % subviews)
   if subviewsCount > 0:
     for i in range(0, subviewsCount):
       subview = fb.evaluateExpression('(id)[%s objectAtIndex:%i]' % (subviews, i))

--- a/commands/FBDebugCommands.py
+++ b/commands/FBDebugCommands.py
@@ -32,7 +32,7 @@ class FBWatchInstanceVariableCommand(fb.FBCommand):
     objectAddress = int(fb.evaluateObjectExpression(commandForObject), 0)
 
     ivarOffsetCommand = '(ptrdiff_t)ivar_getOffset((void*)object_getInstanceVariable((id){}, "{}", 0))'.format(objectAddress, ivarName)
-    ivarOffset = int(fb.evaluateExpression(ivarOffsetCommand), 0)
+    ivarOffset = fb.evaluateIntegerExpression(ivarOffsetCommand)
 
     # A multi-statement command allows for variables scoped to the command, not permanent in the session like $variables.
     ivarSizeCommand = ('unsigned int size = 0;'

--- a/fblldbbase.py
+++ b/fblldbbase.py
@@ -63,7 +63,7 @@ def evaluateIntegerExpression(expression, printErrors=True):
     output = output[2:]
   elif output.startswith('\\'): # Or as \0 (Dec)
     output = output[1:]
-  return int(output, 16)
+  return int(output, 0)
 
 def evaluateBooleanExpression(expression, printErrors=True):
   return (int(evaluateIntegerExpression('(BOOL)(' + expression + ')', printErrors)) != 0)


### PR DESCRIPTION
This is a follow up to https://github.com/facebook/chisel/pull/119. Now `evaluateIntegerExpression()` will accept an integer literal of any base and return the base10 value. Also made code more consistent to call `evaluateIntegerExpression()` where possible instead of `int(evaluateExpression())`