### PR TITLE
[visualize] User-friendly error message for widthless/heightless layers

### DIFF
--- a/commands/FBVisualizationCommands.py
+++ b/commands/FBVisualizationCommands.py
@@ -100,8 +100,15 @@ def _showColor(color):
 
 def _showLayer(layer):
   layer = '(' + layer + ')'
+  size = '((CGRect)[(id)' + layer + ' bounds]).size'
 
-  lldb.debugger.HandleCommand('expr (void)UIGraphicsBeginImageContextWithOptions(((CGRect)[(id)' + layer + ' bounds]).size, NO, 0.0)')
+  width = float(fb.evaluateExpression(size + '.width'))
+  height = float(fb.evaluateExpression(size + '.height'))
+  if width == 0.0 or height == 0.0:
+    print 'Nothing to see here - the size of this element is {} x {}.'.format(width, height)
+    return
+
+  lldb.debugger.HandleCommand('expr (void)UIGraphicsBeginImageContextWithOptions(' + size + ', NO, 0.0)')
   lldb.debugger.HandleCommand('expr (void)[(id)' + layer + ' renderInContext:(void *)UIGraphicsGetCurrentContext()]')
 
   frame = lldb.debugger.GetSelectedTarget().GetProcess().GetSelectedThread().GetSelectedFrame()


### PR DESCRIPTION
If you attempt to visualize a view or layer with 0 width or height, you get a pretty inscrutable error message:
```
(lldb) visualize 0x7fa1285024b0
Nov  1 13:52:00  ChiselTestApp[87971] <Error>: CGContextSaveGState: invalid context 0x0. If you want to see the backtrace, please set CG_CONTEXT_SHOW_BACKTRACE environmental variable.
Nov  1 13:52:00  ChiselTestApp[87971] <Error>: CGContextSaveGState: invalid context 0x0. If you want to see the backtrace, please set CG_CONTEXT_SHOW_BACKTRACE environmental variable.
Nov  1 13:52:00  ChiselTestApp[87971] <Error>: CGContextSetFillColorWithColor: invalid context 0x0. If you want to see the backtrace, please set CG_CONTEXT_SHOW_BACKTRACE environmental variable.
Nov  1 13:52:00  ChiselTestApp[87971] <Error>: CGContextAddRect: invalid context 0x0. If you want to see the backtrace, please set CG_CONTEXT_SHOW_BACKTRACE environmental variable.
Nov  1 13:52:00  ChiselTestApp[87971] <Error>: CGContextDrawPath: invalid context 0x0. If you want to see the backtrace, please set CG_CONTEXT_SHOW_BACKTRACE environmental variable.
Nov  1 13:52:00  ChiselTestApp[87971] <Error>: CGContextRestoreGState: invalid context 0x0. If you want to see the backtrace, please set CG_CONTEXT_SHOW_BACKTRACE environmental variable.
Nov  1 13:52:00  ChiselTestApp[87971] <Error>: CGContextRestoreGState: invalid context 0x0. If you want to see the backtrace, please set CG_CONTEXT_SHOW_BACKTRACE environmental variable.
Could not get image data.
```

With this change, we proactively generate a more user-friendly error message when the width or height of a layer is 0:

```
(lldb) visualize 0x7ff3fca37030
Nothing to see here - the size of this element is 0.0 x 1.5.
```