### PR TITLE
add a memory warning command

### DIFF
--- a/commands/FBDebugCommands.py
+++ b/commands/FBDebugCommands.py
@@ -11,6 +11,7 @@ def lldbcommands():
     FBWatchInstanceVariableCommand(),
     FBFrameworkAddressBreakpointCommand(),
     FBMethodBreakpointCommand(),
+    FBMemoryWarningCommand(),
   ]
 
 class FBWatchInstanceVariableCommand(fb.FBCommand):
@@ -173,3 +174,13 @@ def classItselfImplementsSelector(klass, selector):
     return False
   else:
     return True
+
+class FBMemoryWarningCommand(fb.FBCommand):
+  def name(self):
+    return 'mwarning'
+
+  def description(self):
+    return 'simulate a memory warning'
+
+  def run(self, arguments, options):
+    lldb.debugger.HandleCommand('expr (void)[[UIApplication sharedApplication] performSelector:@selector(_performMemoryWarning)];')


### PR DESCRIPTION
simulator have memory warning command, but device don't have. sometimes we want to simulate a memory warning to app in device

'mwarning' can help people simulate a memory warning

(lldb) mwarning
2015-12-26 23:35:25.377 TLLDB[3557:78497] didReceiveMemoryWarning
2015-12-26 23:35:25.378 TLLDB[3557:78497] didReceiveMemoryWarning
