### PR TITLE
Use correct UI/NSResponder class in presponder (fixes #134)

### DIFF
--- a/commands/FBPrintCommands.py
+++ b/commands/FBPrintCommands.py
@@ -176,8 +176,14 @@ class FBPrintUpwardResponderChain(fb.FBCommand):
 
   def run(self, arguments, options):
     startResponder = arguments[0]
-    if not fb.evaluateBooleanExpression('(BOOL)[(id)' + startResponder + ' isKindOfClass:[UIResponder class]]') and not fb.evaluateBooleanExpression('(BOOL)[(id)' + startResponder + ' isKindOfClass:[NSResponder class]]'):
-      print 'Whoa, ' + startResponder + ' is not a UI/NSResponder. =('
+    
+    isMac = runtimeHelpers.isMacintoshArch()
+    responderClass = 'UIResponder'
+    if isMac:
+      responderClass = 'NSResponder'
+
+    if not fb.evaluateBooleanExpression('(BOOL)[(id)' + startResponder + ' isKindOfClass:[' + responderClass + ' class]]'):
+      print 'Whoa, ' + startResponder + ' is not a ' + responderClass + '. =('
       return
 
     _printIterative(startResponder, _responderChain)


### PR DESCRIPTION
Tests only the appropriate class for the platform.

Verified working on OS X:
![ss 2016-01-04 at 23 21 36](https://cloud.githubusercontent.com/assets/143944/12109818/8d92a560-b33a-11e5-81cd-443c8bde4c56.png)

Verified working on iOS:
![ss 2016-01-04 at 23 19 42](https://cloud.githubusercontent.com/assets/143944/12109824/97e76d02-b33a-11e5-93ca-b19c23e94c65.png)
