### PR TITLE
Rename e{objc,swift} to {objc,swift}e

### DIFF
--- a/commands/FBAccessibilityCommands.py
+++ b/commands/FBAccessibilityCommands.py
@@ -81,9 +81,9 @@ def forceStartAccessibilityServer():
   if not fb.evaluateBooleanExpression('[UIView instancesRespondToSelector:@selector(_accessibilityElementsInContainer:)]'):
     #Starting accessibility server is different for simulator and device
     if isRunningInSimulator():
-      lldb.debugger.HandleCommand('eobjc (void)[[UIApplication sharedApplication] accessibilityActivate]')
+      lldb.debugger.HandleCommand('objce (void)[[UIApplication sharedApplication] accessibilityActivate]')
     else:
-      lldb.debugger.HandleCommand('eobjc (void)[[[UIApplication sharedApplication] _accessibilityBundlePrincipalClass] _accessibilityStartServer]')
+      lldb.debugger.HandleCommand('objce (void)[[[UIApplication sharedApplication] _accessibilityBundlePrincipalClass] _accessibilityStartServer]')
 
 def accessibilityLabel(view):
   #using Apple private API to get real value of accessibility string for element.

--- a/commands/FBAutoLayoutCommands.py
+++ b/commands/FBAutoLayoutCommands.py
@@ -40,8 +40,8 @@ def setBorderOnAmbiguousViewRecursive(view, width, color):
   isAmbiguous = fb.evaluateBooleanExpression('(BOOL)[%s hasAmbiguousLayout]' % view)
   if isAmbiguous:
     layer = viewHelpers.convertToLayer(view)
-    lldb.debugger.HandleCommand('eobjc (void)[%s setBorderWidth:(CGFloat)%s]' % (layer, width))
-    lldb.debugger.HandleCommand('eobjc (void)[%s setBorderColor:(CGColorRef)[(id)[UIColor %sColor] CGColor]]' % (layer, color))
+    lldb.debugger.HandleCommand('objce (void)[%s setBorderWidth:(CGFloat)%s]' % (layer, width))
+    lldb.debugger.HandleCommand('objce (void)[%s setBorderColor:(CGColorRef)[(id)[UIColor %sColor] CGColor]]' % (layer, color))
 
   subviews = fb.evaluateExpression('(id)[%s subviews]' % view)
   subviewsCount = int(fb.evaluateExpression('(int)[(id)%s count]' % subviews))

--- a/commands/FBComponentCommands.py
+++ b/commands/FBComponentCommands.py
@@ -32,10 +32,10 @@ class FBComponentsDebugCommand(fb.FBCommand):
 
   def run(self, arguments, options):
     if options.set:
-      lldb.debugger.HandleCommand('eobjc (void)[CKComponentDebugController setDebugMode:YES]')
+      lldb.debugger.HandleCommand('objce (void)[CKComponentDebugController setDebugMode:YES]')
       print 'Debug mode for ComponentKit has been set.'
     elif options.unset:
-      lldb.debugger.HandleCommand('eobjc (void)[CKComponentDebugController setDebugMode:NO]')
+      lldb.debugger.HandleCommand('objce (void)[CKComponentDebugController setDebugMode:NO]')
       print 'Debug mode for ComponentKit has been unset.'
     else:
       print 'No option for ComponentKit Debug mode specified.'

--- a/commands/FBDisplayCommands.py
+++ b/commands/FBDisplayCommands.py
@@ -60,8 +60,8 @@ class FBDrawBorderCommand(fb.FBCommand):
 
   def run(self, args, options):
     def setBorder(layer, width, color, colorClass):
-      lldb.debugger.HandleCommand('eobjc (void)[%s setBorderWidth:(CGFloat)%s]' % (layer, width))
-      lldb.debugger.HandleCommand('eobjc (void)[%s setBorderColor:(CGColorRef)[(id)[%s %sColor] CGColor]]' % (layer, colorClass, color))
+      lldb.debugger.HandleCommand('objce (void)[%s setBorderWidth:(CGFloat)%s]' % (layer, width))
+      lldb.debugger.HandleCommand('objce (void)[%s setBorderColor:(CGColorRef)[(id)[%s %sColor] CGColor]]' % (layer, colorClass, color))
 
     obj = args[0]
     depth = int(options.depth)
@@ -111,7 +111,7 @@ class FBRemoveBorderCommand(fb.FBCommand):
 
   def run(self, args, options):
     def setUnborder(layer):
-        lldb.debugger.HandleCommand('eobjc (void)[%s setBorderWidth:(CGFloat)%s]' % (layer, 0))
+        lldb.debugger.HandleCommand('objce (void)[%s setBorderWidth:(CGFloat)%s]' % (layer, 0))
 
     obj = args[0]
     depth = int(options.depth)

--- a/commands/FBInvocationCommands.py
+++ b/commands/FBInvocationCommands.py
@@ -114,8 +114,8 @@ def prettyPrintInvocation(frame, invocation):
     for argDescription in argDescriptions:
       s = re.sub(r'argument [0-9]+: ', '', argDescription)
 
-      lldb.debugger.HandleCommand('eobjc void *$v')
-      lldb.debugger.HandleCommand('eobjc (void)[' + invocation + ' getArgument:&$v atIndex:' + str(index) + ']')
+      lldb.debugger.HandleCommand('objce void *$v')
+      lldb.debugger.HandleCommand('objce (void)[' + invocation + ' getArgument:&$v atIndex:' + str(index) + ']')
 
       address = findArgAdressAtIndexFromStackFrame(frame, index)
 

--- a/commands/FBPrintCommands.py
+++ b/commands/FBPrintCommands.py
@@ -595,7 +595,7 @@ class FBPrintObjectInSwift(fb.FBCommand):
 
 class FBExpressionInObjc(fb.FBCommand):
   def name(self):
-    return 'eobjc'
+    return 'objce'
 
   def description(self):
     return 'Run expression run in an ObjC++ context. (Shortcut for "expression -l ObjC++" )'
@@ -616,7 +616,7 @@ class FBExpressionInObjc(fb.FBCommand):
 
 class FBExpressionInSwift(fb.FBCommand):
   def name(self):
-    return 'eswift'
+    return 'swifte'
 
   def description(self):
     return 'Run expression run in a Swift context. (Shortcut for "expression -l Swift" )'

--- a/commands/FBVisualizationCommands.py
+++ b/commands/FBVisualizationCommands.py
@@ -83,9 +83,9 @@ def _showColor(color):
         colorToUse = '[UIColor colorWithCIColor:(CIColor *){}]'.format(color)
 
     imageSize = 58
-    lldb.debugger.HandleCommand('eobjc (void)UIGraphicsBeginImageContextWithOptions((CGSize)CGSizeMake({imageSize}, {imageSize}), NO, 0.0)'.format(imageSize=imageSize))
-    lldb.debugger.HandleCommand('eobjc (void)[(id){} setFill]'.format(colorToUse))
-    lldb.debugger.HandleCommand('eobjc (void)UIRectFill((CGRect)CGRectMake(0.0, 0.0, {imageSize}, {imageSize}))'.format(imageSize=imageSize))
+    lldb.debugger.HandleCommand('objce (void)UIGraphicsBeginImageContextWithOptions((CGSize)CGSizeMake({imageSize}, {imageSize}), NO, 0.0)'.format(imageSize=imageSize))
+    lldb.debugger.HandleCommand('objce (void)[(id){} setFill]'.format(colorToUse))
+    lldb.debugger.HandleCommand('objce (void)UIRectFill((CGRect)CGRectMake(0.0, 0.0, {imageSize}, {imageSize}))'.format(imageSize=imageSize))
 
     frame = lldb.debugger.GetSelectedTarget().GetProcess().GetSelectedThread().GetSelectedFrame()
     result = frame.EvaluateExpression('(UIImage *)UIGraphicsGetImageFromCurrentImageContext()')
@@ -96,7 +96,7 @@ def _showColor(color):
       image = result.GetValue()
       _showImage(image)
 
-    lldb.debugger.HandleCommand('eobjc (void)UIGraphicsEndImageContext()')
+    lldb.debugger.HandleCommand('objce (void)UIGraphicsEndImageContext()')
 
 def _showLayer(layer):
   layer = '(' + layer + ')'
@@ -108,8 +108,8 @@ def _showLayer(layer):
     print 'Nothing to see here - the size of this element is {} x {}.'.format(width, height)
     return
 
-  lldb.debugger.HandleCommand('eobjc (void)UIGraphicsBeginImageContextWithOptions(' + size + ', NO, 0.0)')
-  lldb.debugger.HandleCommand('eobjc (void)[(id)' + layer + ' renderInContext:(void *)UIGraphicsGetCurrentContext()]')
+  lldb.debugger.HandleCommand('objce (void)UIGraphicsBeginImageContextWithOptions(' + size + ', NO, 0.0)')
+  lldb.debugger.HandleCommand('objce (void)[(id)' + layer + ' renderInContext:(void *)UIGraphicsGetCurrentContext()]')
 
   frame = lldb.debugger.GetSelectedTarget().GetProcess().GetSelectedThread().GetSelectedFrame()
   result = frame.EvaluateExpression('(UIImage *)UIGraphicsGetImageFromCurrentImageContext()')
@@ -119,7 +119,7 @@ def _showLayer(layer):
     image = result.GetValue()
     _showImage(image)
 
-  lldb.debugger.HandleCommand('eobjc (void)UIGraphicsEndImageContext()')
+  lldb.debugger.HandleCommand('objce (void)UIGraphicsEndImageContext()')
 
 def _dataIsImage(data):
   data = '(' + data + ')'

--- a/fblldbviewhelpers.py
+++ b/fblldbviewhelpers.py
@@ -13,10 +13,10 @@ import fblldbbase as fb
 import fblldbobjcruntimehelpers as runtimeHelpers
 
 def flushCoreAnimationTransaction():
-  lldb.debugger.HandleCommand('eobjc (void)[CATransaction flush]')
+  lldb.debugger.HandleCommand('objce (void)[CATransaction flush]')
 
 def setViewHidden(object, hidden):
-  lldb.debugger.HandleCommand('eobjc (void)[' + object + ' setHidden:' + str(int(hidden)) + ']')
+  lldb.debugger.HandleCommand('objce (void)[' + object + ' setHidden:' + str(int(hidden)) + ']')
   flushCoreAnimationTransaction()
 
 def maskView(viewOrLayer, color, alpha):
@@ -31,16 +31,16 @@ def maskView(viewOrLayer, color, alpha):
                                                size.GetChildMemberWithName('height').GetValue())
   mask = fb.evaluateExpression('(id)[[UIView alloc] initWithFrame:%s]' % rectExpr)
 
-  lldb.debugger.HandleCommand('eobjc (void)[%s setTag:(NSInteger)%s]' % (mask, viewOrLayer))
-  lldb.debugger.HandleCommand('eobjc (void)[%s setBackgroundColor:[UIColor %sColor]]' % (mask, color))
-  lldb.debugger.HandleCommand('eobjc (void)[%s setAlpha:(CGFloat)%s]' % (mask, alpha))
-  lldb.debugger.HandleCommand('eobjc (void)[%s addSubview:%s]' % (window, mask))
+  lldb.debugger.HandleCommand('objce (void)[%s setTag:(NSInteger)%s]' % (mask, viewOrLayer))
+  lldb.debugger.HandleCommand('objce (void)[%s setBackgroundColor:[UIColor %sColor]]' % (mask, color))
+  lldb.debugger.HandleCommand('objce (void)[%s setAlpha:(CGFloat)%s]' % (mask, alpha))
+  lldb.debugger.HandleCommand('objce (void)[%s addSubview:%s]' % (window, mask))
   flushCoreAnimationTransaction()
 
 def unmaskView(viewOrLayer):
   window = fb.evaluateExpression('(UIWindow *)[[UIApplication sharedApplication] keyWindow]')
   mask = fb.evaluateExpression('(UIView *)[%s viewWithTag:(NSInteger)%s]' % (window, viewOrLayer))
-  lldb.debugger.HandleCommand('eobjc (void)[%s removeFromSuperview]' % mask)
+  lldb.debugger.HandleCommand('objce (void)[%s removeFromSuperview]' % mask)
   flushCoreAnimationTransaction()
 
 def convertPoint(x, y, fromViewOrLayer, toViewOrLayer):
@@ -113,4 +113,4 @@ def upwardsRecursiveDescription(view, maxDepth=0):
   return builder
 
 def slowAnimation(speed=1):
-  lldb.debugger.HandleCommand('eobjc (void)[[[UIApplication sharedApplication] windows] setValue:@(%s) forKeyPath:@"layer.speed"]' % speed)
+  lldb.debugger.HandleCommand('objce (void)[[[UIApplication sharedApplication] windows] setValue:@(%s) forKeyPath:@"layer.speed"]' % speed)


### PR DESCRIPTION
In #121, two new chisel commands were added `eobjc` and `eswift`, for explicitly evaluating with a specific language. However this impacts the sanctity of the `e` command in lldb :stuck_out_tongue_winking_eye:. Sure I can from now on use `ex` where I previously used `e`, but we could also change the convention of how these commands are named.