### PR TITLE
Add present and dismiss commands for UIViewController

### DIFF
--- a/commands/FBDisplayCommands.py
+++ b/commands/FBDisplayCommands.py
@@ -10,6 +10,7 @@
 import lldb
 
 import fblldbviewhelpers as viewHelpers
+import fblldbviewcontrollerhelpers as viewControllerHelpers
 import fblldbbase as fb
 import fblldbobjcruntimehelpers as runtimeHelpers
 
@@ -22,6 +23,8 @@ def lldbcommands():
     FBUnmaskViewCommand(),
     FBShowViewCommand(),
     FBHideViewCommand(),
+    FBPresentViewControllerCommand(),
+    FBDismissViewControllerCommand(),
     FBSlowAnimationCommand(),
     FBUnslowAnimationCommand()
   ]
@@ -202,6 +205,34 @@ class FBHideViewCommand(fb.FBCommand):
 
   def run(self, args, options):
     viewHelpers.setViewHidden(args[0], True)
+
+
+class FBPresentViewControllerCommand(fb.FBCommand):
+  def name(self):
+    return 'present'
+
+  def description(self):
+    return 'Present a view controller.'
+
+  def args(self):
+    return [ fb.FBCommandArgument(arg='viewController', type='UIViewController *', help='The view controller to present.') ]
+
+  def run(self, args, option):
+    viewControllerHelpers.presentViewController(args[0])
+
+
+class FBDismissViewControllerCommand(fb.FBCommand):
+  def name(self):
+    return 'dismiss'
+
+  def description(self):
+    return 'Dismiss a presented view controller.'
+
+  def args(self):
+    return [ fb.FBCommandArgument(arg='viewController', type='UIViewController *', help='The view controller to dismiss.') ]
+
+  def run(self, args, option):
+    viewControllerHelpers.dismissViewController(args[0])
 
 
 class FBSlowAnimationCommand(fb.FBCommand):

--- a/fblldbviewcontrollerhelpers.py
+++ b/fblldbviewcontrollerhelpers.py
@@ -12,6 +12,32 @@ import lldb
 import fblldbbase as fb
 import fblldbobjcruntimehelpers as runtimeHelpers
 
+def presentViewController(viewController):
+  vc = '(%s)' % (viewController)
+  
+  if fb.evaluateBooleanExpression('%s != nil && ((BOOL)[(id)%s isKindOfClass:(Class)[UIViewController class]])' % (vc, vc)):
+    notPresented = fb.evaluateBooleanExpression('[%s presentingViewController] == nil' % vc)
+    
+    if notPresented:
+      lldb.debugger.HandleCommand('expr (void)[[[[UIApplication sharedApplication] keyWindow] rootViewController] presentViewController:%s animated:YES completion:nil]' % vc)
+    else:
+      raise Exception('Argument is already presented')
+  else:
+    raise Exception('Argument must be a UIViewController')
+
+def dismissViewController(viewController):
+  vc = '(%s)' % (viewController)
+  
+  if fb.evaluateBooleanExpression('%s != nil && ((BOOL)[(id)%s isKindOfClass:(Class)[UIViewController class]])' % (vc, vc)):
+    isPresented = fb.evaluateBooleanExpression('[%s presentingViewController] != nil' % vc)
+    
+    if isPresented:
+      lldb.debugger.HandleCommand('expr (void)[(UIViewController *)%s dismissViewControllerAnimated:YES completion:nil]' % vc)
+    else:
+      raise Exception('Argument must be presented')
+  else:
+    raise Exception('Argument must be a UIViewController')
+
 def viewControllerRecursiveDescription(vc):
   return _recursiveViewControllerDescriptionWithPrefixAndChildPrefix(fb.evaluateObjectExpression(vc), '', '', '')
 


### PR DESCRIPTION
How I tested:

```
(lldb) expr UIViewController *$avc = (UIViewController *)[[UIViewController alloc] init]
(lldb) dismiss $avc
Traceback (most recent call last):
  File "/Users/alan/repositories/github/chisel/fblldb.py", line 79, in runCommand
    command.run(args, options)
  File "/Users/alan/repositories/github/chisel/commands/FBDisplayCommands.py", line 235, in run
    viewControllerHelpers.dismissViewController(args[0])
  File "/Users/alan/repositories/github/chisel/fblldbviewcontrollerhelpers.py", line 37, in dismissViewController
    raise Exception('Argument must be presented')
Exception: Argument must be presented
(lldb) present $avc
(lldb) c
Process 8420 resuming
(lldb) present $avc
Traceback (most recent call last):
  File "/Users/alan/repositories/github/chisel/fblldb.py", line 79, in runCommand
    command.run(args, options)
  File "/Users/alan/repositories/github/chisel/commands/FBDisplayCommands.py", line 221, in run
    viewControllerHelpers.presentViewController(args[0])
  File "/Users/alan/repositories/github/chisel/fblldbviewcontrollerhelpers.py", line 24, in presentViewController
    raise Exception('Argument is already presented')
Exception: Argument is already presented
(lldb) dismiss $avc
(lldb) c
```