### PR TITLE
Provide a help string when registering commands

### DIFF
--- a/fblldb.py
+++ b/fblldb.py
@@ -41,7 +41,7 @@ def loadCommandsInDirectory(commandsDirectory):
 def loadCommand(module, command, directory, filename, extension):
   func = makeRunCommand(command, os.path.join(directory, filename + extension))
   name = command.name()
-  helpText = command.description().split('\n', 1)[0] # first line of description
+  helpText = command.description().splitlines()[0] # first line of description
 
   key = filename + '_' + name
 

--- a/fblldb.py
+++ b/fblldb.py
@@ -41,6 +41,7 @@ def loadCommandsInDirectory(commandsDirectory):
 def loadCommand(module, command, directory, filename, extension):
   func = makeRunCommand(command, os.path.join(directory, filename + extension))
   name = command.name()
+  helpText = command.description().split('\n', 1)[0] # first line of description
 
   key = filename + '_' + name
 
@@ -49,7 +50,10 @@ def loadCommand(module, command, directory, filename, extension):
   functionName = '__' + key
 
   lldb.debugger.HandleCommand('script ' + functionName + ' = sys.modules[\'' + module.__name__ + '\']._loadedFunctions[\'' + key + '\']')
-  lldb.debugger.HandleCommand('command script add -f ' + functionName + ' ' + name)
+  lldb.debugger.HandleCommand('command script add --help "{help}" --function {function} {name}'.format(
+    help=helpText.replace('"', '\\"'), # escape quotes
+    function=functionName,
+    name=name))
 
 def makeRunCommand(command, filename):
   def runCommand(debugger, input, result, dict):


### PR DESCRIPTION
I don't know when it was first added, but `command script add` has a `--help` flag, which defines the help text to show in the output of the `help` command.

This change calls the description method on each command, extracts the first line, and then passes that as the help string when registering the command.

Example output:

```
pa11y        -- Print accessibility labels of all views in hierarchy of <aView>
pa11yi       -- Print accessibility identifiers of all views in hierarchy of <aView>
pactions     -- Print the actions and targets of a control.
paltrace     -- Print the Auto Layout trace for the given view. Defaults to the key window.
panim        -- Prints if the code is currently execution with a UIView animation block.
pbcopy       -- Print object and copy output to clipboard
```