### PR TITLE
Evaluate with SetTrapExceptions set to False

### DIFF
--- a/fblldbbase.py
+++ b/fblldbbase.py
@@ -42,6 +42,7 @@ def evaluateExpressionValue(expression, printErrors=True):
   frame = lldb.debugger.GetSelectedTarget().GetProcess().GetSelectedThread().GetSelectedFrame()
   options = lldb.SBExpressionOptions()
   options.SetLanguage(lldb.eLanguageTypeObjC_plus_plus)
+  options.SetTrapExceptions(False)
   value = frame.EvaluateExpression(expression, options)
   error = value.GetError()
 
@@ -61,7 +62,9 @@ def evaluateInputExpression(expression, printErrors=True):
     return evaluateExpressionValue(expression, printErrors).GetValue()
 
   frame = lldb.debugger.GetSelectedTarget().GetProcess().GetSelectedThread().GetSelectedFrame()
-  value = frame.EvaluateExpression(expression)
+  options = lldb.SBExpressionOptions()
+  options.SetTrapExceptions(False)
+  value = frame.EvaluateExpression(expression, options)
   error = value.GetError()
 
   if printErrors and error.Fail():


### PR DESCRIPTION
With this change, code that happens to throw and catch an internal exception will now successfully evaluate to completion. Without this, no result would be returned, and instead this error would be printed to the console:

    error: Execution was interrupted, reason: internal ObjC exception breakpoint(-3)..
    The process has been returned to the state before expression evaluation.