### PR TITLE
[pinternals] -a option added

### DIFF
--- a/commands/FBPrintCommands.py
+++ b/commands/FBPrintCommands.py
@@ -268,7 +268,11 @@ class FBPrintInternals(fb.FBCommand):
   def run(self, arguments, options):
     object = fb.evaluateObjectExpression(arguments[0])
     if options.appleWay:
-        command = 'po [{} _ivarDescription]'.format(object)
+        if fb.evaluateBooleanExpression('[{} respondsToSelector:@selector(_ivarDescription)]'.format(object)):
+            command = 'po [{} _ivarDescription]'.format(object)
+        else:
+            print 'Sorry, but it seems Apple dumped the _ivarDescription method'
+            return
     else:
         objectClass = fb.evaluateExpressionValue('(id)[(id)(' + object + ') class]').GetObjectDescription()
         command = 'p *(({} *)((id){}))'.format(objectClass, object)

--- a/commands/FBPrintCommands.py
+++ b/commands/FBPrintCommands.py
@@ -259,12 +259,19 @@ class FBPrintInternals(fb.FBCommand):
 
   def args(self):
     return [ fb.FBCommandArgument(arg='object', type='id', help='Object expression to be evaluated.') ]
+  
+  def options(self):
+    return [
+          fb.FBCommandArgument(arg='appleWay', short='-a', long='--apple', boolean=True, default=False, help='Print ivars the apple way')
+    ]
 
   def run(self, arguments, options):
     object = fb.evaluateObjectExpression(arguments[0])
-    objectClass = fb.evaluateExpressionValue('(id)[(id)(' + object + ') class]').GetObjectDescription()
-
-    command = 'p *(({} *)((id){}))'.format(objectClass, object)
+    if options.appleWay:
+        command = 'po [{} _ivarDescription]'.format(object)
+    else:
+        objectClass = fb.evaluateExpressionValue('(id)[(id)(' + object + ') class]').GetObjectDescription()
+        command = 'p *(({} *)((id){}))'.format(objectClass, object)
     lldb.debugger.HandleCommand(command)
 
 


### PR DESCRIPTION
`pinternals` command shows object description in less human-readable form than private Apple method `_ivarDescription`. This change keeps the default behaviour of the command, but adds an `-a (--apple)` option to print internals in the Apple way.

```
(lldb) pint -a $foo
<Foo: 0x170048940>:
in Foo:
    _view (UIView*): <UIView: 0x100204830>
    _layer (CALayer*): <CALayer: 0x170026ca0>
in Bar:
    _array (NSArray*): <__NSArrayI: 0x170024480>
    _dictionary (NSDictionary*): <__NSDictionaryI: 0x17007c900>
in NSObject:
    isa (Class): Foo (isa, 0x1a10001a245)
```

versus

```
(lldb) pint $foo
(Foo) $25 = {
  Bar = {
    _array = 0x0000000170024480 @"2 elements"
    _dictionary = 0x000000017007c900 2 key/value pairs
  }
  _view = 0x0000000100204830
  _layer = 0x0000000170026ca0
}
```
