### PR TITLE
Remove outdated CKComponentAction type summary

### DIFF
--- a/commands/FBComponentCommands.py
+++ b/commands/FBComponentCommands.py
@@ -5,10 +5,6 @@ import os
 import lldb
 import fblldbbase as fb
 
-def lldbinit():
-  # Tell LLDB to print CKComponentAction as a c-string
-  lldb.debugger.HandleCommand('type summary add --summary-string "${var%c-string}" CKComponentAction')
-
 def lldbcommands():
   return [
     FBComponentsDebugCommand(),


### PR DESCRIPTION
`CKComponentAction` is no longer a `typedef` for `SEL`. See https://github.com/facebook/componentkit/pull/676

cc @ocrickard @eczarny