### PR TITLE
Add delay command

### DIFF
--- a/commands/FBDelay.py
+++ b/commands/FBDelay.py
@@ -1,0 +1,37 @@
+#!/usr/bin/python
+from threading import Timer
+import fblldbbase as fb
+import fblldbobjcruntimehelpers as runtimeHelpers
+import lldb
+import string
+
+
+def lldbcommands():
+  return [
+    FBDelay()
+  ]
+
+class FBDelay(fb.FBCommand):
+  def name(self):
+    return 'zzz'
+
+  def description(self):
+    return 'Executes specified lldb command after delay.'
+
+  def args(self):
+    return [
+      fb.FBCommandArgument(arg='delay in seconds', type='float', help='time to wait before executing specified command'),
+      fb.FBCommandArgument(arg='lldb command', type='string', help='another lldb command to execute after specified delay', default='process interrupt')
+    ]
+
+  def run(self, arguments, options):
+    lldb.debugger.SetAsync(True)
+    lldb.debugger.HandleCommand('process continue')
+    delay = float(arguments[0])
+    command = str(arguments[1])
+    t = Timer(delay, lambda: self.runDelayed(command))
+    t.start()
+
+  def runDelayed(self, command):
+    lldb.debugger.HandleCommand('process interrupt')
+    lldb.debugger.HandleCommand(command)


### PR DESCRIPTION
This adds a delayed execution of commands for lldb

## Reasoning

Often when debugging involved user interaction or interactive transitions in simulator, it takes some time to setup the interaction I need. Once setup, it is not unheard of that I can't switch away from simulator: if gesture-driven animation is in flight, switching away from simulator might interrupt it.

## Usage

This is why I found it useful to do following:

`$ zzz 3 "process interrupt"` (== `$ zzz 3`)
`$ zzz 3 pcomponents` 
etc… 

This restarts execution, gives me 3 seconds to setup my interaction, and executes specified command afterwards.

My python is quite rusty, any feedback is highly appreciated!