### PR TITLE
Force start accessibility for `pa11yi` command

### DIFF
--- a/commands/FBAccessibilityCommands.py
+++ b/commands/FBAccessibilityCommands.py
@@ -35,7 +35,7 @@ class FBPrintAccessibilityLabels(fb.FBCommand):
     return [ fb.FBCommandArgument(arg='aView', type='UIView*', help='The view to print the hierarchy of.', default='(id)[[UIApplication sharedApplication] keyWindow]') ]
 
   def run(self, arguments, options):
-    forceStartAccessibilityServer();
+    forceStartAccessibilityServer()
     printAccessibilityHierarchy(arguments[0])
 
 class FBPrintAccessibilityIdentifiers(fb.FBCommand):
@@ -49,6 +49,7 @@ class FBPrintAccessibilityIdentifiers(fb.FBCommand):
     return [ fb.FBCommandArgument(arg='aView', type='UIView*', help='The view to print the hierarchy of.', default='(id)[[UIApplication sharedApplication] keyWindow]') ]
 
   def run(self, arguments, option):
+    forceStartAccessibilityServer()
     printAccessibilityIdentifiersHierarchy(arguments[0])
 
 class FBFindViewByAccessibilityLabelCommand(fb.FBCommand):


### PR DESCRIPTION
On the `pa11yi` command an error is returned:

```
UIWindow (id)[[UIApplication sharedApplication] keyWindow]
error: error: Execution was interrupted, reason: Attempted to dereference an invalid ObjC Object or send it an unrecognized selector.
The process has been returned to the state before expression evaluation.
error: error: use of undeclared identifier 'None'
```

The `pa11y` commands works without any problem. The reason of this error is not started Accessibility Server.