### PR TITLE
Support debugging information overlay

### DIFF
--- a/commands/FBDebugCommands.py
+++ b/commands/FBDebugCommands.py
@@ -12,6 +12,7 @@ def lldbcommands():
     FBFrameworkAddressBreakpointCommand(),
     FBMethodBreakpointCommand(),
     FBMemoryWarningCommand(),
+    FBDebuggingInformationOverlayCommand(),
   ]
 
 class FBWatchInstanceVariableCommand(fb.FBCommand):
@@ -184,3 +185,27 @@ class FBMemoryWarningCommand(fb.FBCommand):
 
   def run(self, arguments, options):
     fb.evaluateEffect('[[UIApplication sharedApplication] performSelector:@selector(_performMemoryWarning)]')
+
+class FBDebuggingInformationOverlayCommand(fb.FBCommand):
+  def name(self):
+    return 'dio'
+
+  def description(self):
+    return 'Enable the feature that shows a float debugging information overlay window. Continue program after executing this command, then tap the status bar with two fingers at the same time to show the overlay window. Only works on iOS device.'
+
+  def run(self, arguments, options):
+    if not objc.isIOSDevice():
+      print 'Sorry, but the ' + `self.name()` + ' command only works on iOS device.'
+      return
+
+    codeString = r'''
+    @import Foundation;
+    id DebugClass = NSClassFromString(@"UIDebuggingInformationOverlay");
+    
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+    [DebugClass performSelector:NSSelectorFromString(@"prepareDebuggingOverlay")];
+    });
+    '''
+
+    lldb.debugger.HandleCommand("expression -lobjc -o -- " + codeString)

--- a/commands/FBDebugCommands.py
+++ b/commands/FBDebugCommands.py
@@ -188,24 +188,11 @@ class FBMemoryWarningCommand(fb.FBCommand):
 
 class FBDebuggingInformationOverlayCommand(fb.FBCommand):
   def name(self):
-    return 'dio'
+    return 'doverlay'
 
   def description(self):
-    return 'Enable the feature that shows a float debugging information overlay window. Continue program after executing this command, then tap the status bar with two fingers at the same time to show the overlay window. Only works on iOS device.'
+    return 'Toggle the float debugging information overlay window. Continue program after executing this command, you can also just tap the status bar with two fingers at the same time to show the overlay window.'
 
   def run(self, arguments, options):
-    if not objc.isIOSDevice():
-      print 'Sorry, but the ' + `self.name()` + ' command only works on iOS device.'
-      return
-
-    codeString = r'''
-    @import Foundation;
-    id DebugClass = NSClassFromString(@"UIDebuggingInformationOverlay");
-    
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-    [DebugClass performSelector:NSSelectorFromString(@"prepareDebuggingOverlay")];
-    });
-    '''
-
-    lldb.debugger.HandleCommand("expression -lobjc -o -- " + codeString)
+    fb.evaluateEffect("[UIDebuggingInformationOverlay prepareDebuggingOverlay]")
+    fb.evaluateEffect("[[UIDebuggingInformationOverlay overlay] toggleVisibility]")


### PR DESCRIPTION
This command, `dio`, enables the feature that shows a float debugging information
overlay window, which could be very helpful for iOS develops and designers.

Continue program after executing this command, then tap the status bar with two
fingers at the same time to show the overlay window. You can dismiss it by tapping the upper-right `Dismiss` button after finishing.

The debugging information provided by this feature includes 'View Hierachy', 'VC Hierachy',
'Ivar Explorer', 'Measure', 'Spec Compare', 'System Color Audit', for now.

For more details, please refer to the original post: http://ryanipete.com/blog/ios/swift/objective-c/uidebugginginformationoverlay/