### PR TITLE
Add Makefile for installing framework

### DIFF
--- a/Chisel/Chisel.xcodeproj/project.pbxproj
+++ b/Chisel/Chisel.xcodeproj/project.pbxproj
@@ -362,7 +362,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.facebook.Chisel;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SKIP_INSTALL = YES;
+				SKIP_INSTALL = NO;
 			};
 			name = Debug;
 		};
@@ -379,7 +379,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.facebook.Chisel;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SKIP_INSTALL = YES;
+				SKIP_INSTALL = NO;
 			};
 			name = Release;
 		};

--- a/Chisel/Makefile
+++ b/Chisel/Makefile
@@ -1,0 +1,10 @@
+PREFIX ?= /usr/local/lib
+
+install:
+	xcodebuild \
+		-scheme Chisel \
+		-configuration Release \
+		-sdk iphonesimulator \
+		install \
+		DSTROOT=/ \
+		INSTALL_PATH="$(PREFIX)"


### PR DESCRIPTION
This allows you to run `make install` with optional environment variables
in order to build and install Chisel.framework.