### PR TITLE
Expose LD_DYLIB_INSTALL_NAME setting for `make`

### DIFF
--- a/Chisel/Makefile
+++ b/Chisel/Makefile
@@ -1,11 +1,16 @@
 PREFIX ?= /usr/local/lib
 
+export INSTALL_NAME = ""
+ifneq ($(LD_DYLIB_INSTALL_NAME), "")
+	INSTALL_NAME = "LD_DYLIB_INSTALL_NAME=$(LD_DYLIB_INSTALL_NAME)"
+endif
+
 install:
 	xcodebuild \
 		-scheme Chisel \
 		-configuration Release \
 		-sdk iphonesimulator \
 		install \
-		LD_DYLIB_INSTALL_NAME="$(LD_DYLIB_INSTALL_NAME)" \
+		$(INSTALL_NAME) \
 		DSTROOT=/ \
 		INSTALL_PATH="$(PREFIX)"

--- a/Chisel/Makefile
+++ b/Chisel/Makefile
@@ -6,5 +6,6 @@ install:
 		-configuration Release \
 		-sdk iphonesimulator \
 		install \
+		LD_DYLIB_INSTALL_NAME="$(LD_DYLIB_INSTALL_NAME)" \
 		DSTROOT=/ \
 		INSTALL_PATH="$(PREFIX)"


### PR DESCRIPTION
This change makes it so that `make` invocations can specify `LD_DYLIB_INSTALL_NAME`. At this time, this is done solely so that homebrew can set the value properly from the outset. Without this, homebew will modify the library after `make` has completed, but modifying a library after code signing means an error will occur when it's loaded at runtime.