### PR TITLE
Share the Chisel scheme

### DIFF
--- a/Chisel/Chisel.xcodeproj/xcshareddata/xcschemes/Chisel.xcscheme
+++ b/Chisel/Chisel.xcodeproj/xcshareddata/xcschemes/Chisel.xcscheme
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0920"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "7ABD178A1DF7F998006118F8"
+               BuildableName = "Chisel.framework"
+               BlueprintName = "Chisel"
+               ReferencedContainer = "container:Chisel.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "7ABD17931DF7F998006118F8"
+               BuildableName = "ChiselTests.xctest"
+               BlueprintName = "ChiselTests"
+               ReferencedContainer = "container:Chisel.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "7ABD178A1DF7F998006118F8"
+            BuildableName = "Chisel.framework"
+            BlueprintName = "Chisel"
+            ReferencedContainer = "container:Chisel.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "7ABD178A1DF7F998006118F8"
+            BuildableName = "Chisel.framework"
+            BlueprintName = "Chisel"
+            ReferencedContainer = "container:Chisel.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "7ABD178A1DF7F998006118F8"
+            BuildableName = "Chisel.framework"
+            BlueprintName = "Chisel"
+            ReferencedContainer = "container:Chisel.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
The 1.7 homebrew update [failed when building on 10.11](https://jenkins.brew.sh/job/Homebrew%20Core%20Pull%20Requests/15963/version=el_capitan/testReport/brew-test-bot/el_capitan/install_chisel/). This change is a Stackoverflow driven solution to the problem (see https://stackoverflow.com/a/33521888). According to that answer, the scheme needs to be shared, and so that's what this change does.

See Homebrew/homebrew-core#22450