### PR TITLE
Improve findinstances handling of Swift subclasses

### DIFF
--- a/Chisel/Chisel.xcodeproj/project.pbxproj
+++ b/Chisel/Chisel.xcodeproj/project.pbxproj
@@ -75,6 +75,7 @@
 				7ABD17981DF7F998006118F8 /* ChiselTests */,
 				7ABD178C1DF7F998006118F8 /* Products */,
 			);
+			indentWidth = 2;
 			sourceTree = "<group>";
 		};
 		7ABD178C1DF7F998006118F8 /* Products */ = {

--- a/Chisel/Chisel/CHLObjcInstanceCommands.mm
+++ b/Chisel/Chisel/CHLObjcInstanceCommands.mm
@@ -129,7 +129,12 @@ void PrintInstances(const char *type, const char *pred)
 {
   NSPredicate *predicate = nil;
   if (pred != nullptr && *pred != '\0') {
-    predicate = [NSPredicate predicateWithFormat:@(pred)];
+    @try {
+      predicate = [NSPredicate predicateWithFormat:@(pred)];
+    } @catch (NSException *e) {
+      printf("Error: Invalid predicate; %s\n", [e reason].UTF8String);
+      return;
+    }
   }
 
   const std::unordered_set<Class> objcClasses = CHLObjcClassSet();

--- a/Chisel/Chisel/CHLObjcInstanceCommands.mm
+++ b/Chisel/Chisel/CHLObjcInstanceCommands.mm
@@ -173,7 +173,7 @@ void PrintInstances(const char *type, const char *pred)
   if (baseClass != Nil) {
     addMatch(baseClass);
   } else {
-    // The given class name hasn't been found, this could be a Swift class which case has
+    // The given class name hasn't been found, this could be a Swift class which has
     // a module name prefix. Loop over all classes to look for matching class names.
     for (auto cls : objcClasses) {
       // SwiftModule.ClassName

--- a/Chisel/Makefile
+++ b/Chisel/Makefile
@@ -1,7 +1,7 @@
 PREFIX ?= /usr/local/lib
 
-export INSTALL_NAME = ""
-ifneq ($(LD_DYLIB_INSTALL_NAME), "")
+export INSTALL_NAME =
+ifneq ($(LD_DYLIB_INSTALL_NAME),)
 	INSTALL_NAME = "LD_DYLIB_INSTALL_NAME=$(LD_DYLIB_INSTALL_NAME)"
 endif
 


### PR DESCRIPTION
Calling `findinstances` currently requires the exact class name. For classes implemented in Swift, the name includes the module name, for example `SuperKit.DuperClass`. This change allows `findinstances` to be called with simply the class name (`DuperClass` in the previous example).

Note: This change does handle the case where more than one module contains a class by that name. For example, if two modules each define a class named `User`, then running `findinstances User` will list instances of both classes.

This pull request also includes a few other small improvements.