### PR TITLE
Fix findinstances quote handling

### DIFF
--- a/commands/FBDebugCommands.py
+++ b/commands/FBDebugCommands.py
@@ -193,6 +193,13 @@ class FBFindInstancesCommand(fb.FBCommand):
   def name(self):
     return 'findinstances'
 
+  def args(self):
+    return [
+      fb.FBCommandArgument(arg='type', help='Class or protocol name'),
+      fb.FBCommandArgument(arg='query', default=' ', # space is a hack to mark optional
+                           help='Query expression, uses NSPredicate syntax')
+    ]
+
   def description(self):
     return """
     Find instances of specified ObjC classes.
@@ -240,16 +247,10 @@ class FBFindInstancesCommand(fb.FBCommand):
       print 'Usage: findinstances <classOrProtocol> [<predicate>]; Run `help findinstances`'
       return
 
-    # Unpack the arguments by hand. The input is entirely in arguments[0].
-    args = arguments[0].strip().split(' ', 1)
-
-    query = args[0]
-    if len(args) > 1:
-      predicate = args[1].strip()
-      # Escape double quotes and backslashes.
-      predicate = re.sub('([\\"])', r'\\\1', predicate)
-    else:
-      predicate = ''
+    query = arguments[0]
+    predicate = arguments[1].strip()
+    # Escape double quotes and backslashes.
+    predicate = re.sub('([\\"])', r'\\\1', predicate)
     call = '(void)PrintInstances("{}", "{}")'.format(query, predicate)
     fb.evaluateExpressionValue(call)
 

--- a/commands/FBDebugCommands.py
+++ b/commands/FBDebugCommands.py
@@ -228,8 +228,8 @@ class FBFindInstancesCommand(fb.FBCommand):
     """
 
   def lex(self, commandLine):
-    # Can't use default shlex splitting because it strip quotes which breaks
-    # NSPredicate syntax. Split the input into type and rest (the query).
+    # Can't use default shlex splitting because it strips quotes, which results
+    # in invalid NSPredicate syntax. Split the input into type and rest (query).
     return commandLine.split(' ', 1)
 
   def run(self, arguments, options):

--- a/commands/FBDebugCommands.py
+++ b/commands/FBDebugCommands.py
@@ -227,6 +227,11 @@ class FBFindInstancesCommand(fb.FBCommand):
     as seen above, see https://github.com/facebook/chisel/wiki/findinstances.
     """
 
+  def lex(self, commandLine):
+    # Can't use default shlex splitting because it strip quotes which breaks
+    # NSPredicate syntax. Split the input into type and rest (the query).
+    return commandLine.split(' ', 1)
+
   def run(self, arguments, options):
     if not self.loadChiselIfNecessary():
       return

--- a/fblldb.py
+++ b/fblldb.py
@@ -11,7 +11,6 @@ import lldb
 
 import imp
 import os
-import shlex
 
 from optparse import OptionParser
 
@@ -57,7 +56,7 @@ def loadCommand(module, command, directory, filename, extension):
 
 def makeRunCommand(command, filename):
   def runCommand(debugger, input, result, dict):
-    splitInput = shlex.split(input)
+    splitInput = command.lex(input)
 
     # OptionParser will throw in the case where you want just one big long argument and no
     # options and you enter something that starts with '-' in the argument. e.g.:

--- a/fblldbbase.py
+++ b/fblldbbase.py
@@ -9,6 +9,7 @@
 
 import lldb
 import json
+import shlex
 
 class FBCommandArgument:
   def __init__(self, short='', long='', arg='', type='', help='', default='', boolean=False):
@@ -32,6 +33,9 @@ class FBCommand:
 
   def description(self):
     return ''
+
+  def lex(self, commandLine):
+    return shlex.split(commandLine)
 
   def run(self, arguments, option):
     pass


### PR DESCRIPTION
Chisel defaults to using `shlex` for splitting the command line. This is useful for arguments that contain spaces, the command line can be written with quotes around those arguments. But this behavior is a problem for for arguments using literal quotes, which can happen with `findinstances`. For example `findinstances NSDictionary any @allKeys == "someKey"`.

This change allows commands to override command line splitting, for the cases where `shlex` is not desired.