### PR TITLE
Make `paltrace` work on selected views

### DIFF
--- a/commands/FBAutoLayoutCommands.py
+++ b/commands/FBAutoLayoutCommands.py
@@ -31,7 +31,9 @@ class FBPrintAutolayoutTrace(fb.FBCommand):
 
   def run(self, arguments, options):
     view = fb.evaluateInputExpression(arguments[0])
-    print fb.describeObject('[{} _autolayoutTrace]'.format(view))
+    opt = fb.evaluateBooleanExpression('[UIView instancesRespondToSelector:@selector(_autolayoutTraceRecursively:)]')
+    traceCall = '_autolayoutTraceRecursively:1' if opt else '_autolayoutTrace'
+    print fb.describeObject('[{} {}]'.format(view, traceCall))
 
 
 def setBorderOnAmbiguousViewRecursive(view, width, color):


### PR DESCRIPTION
Calling `_autolayoutTrace` prints the entire view tree, regardless of which view it's called on, but `_autolayoutTraceRecursively:` prints the tree of the view it's called on.