### PR TITLE
Add command to run commands in sequence

### DIFF
--- a/fblldb.py
+++ b/fblldb.py
@@ -55,7 +55,9 @@ def loadCommand(module, command, directory, filename, extension):
     name=name))
 
 def makeRunCommand(command, filename):
-  def runCommand(debugger, input, result, dict):
+  def runCommand(debugger, input, exe_ctx, result, _):
+    command.result = result
+    command.context = exe_ctx
     splitInput = command.lex(input)
 
     # OptionParser will throw in the case where you want just one big long argument and no


### PR DESCRIPTION
This introduces the `sequence` command, which allows multiple commands as a single command.

Example A:

```
breakpoint command add -o 'sequence bt; po someVar'
```

Example B:

```
command regex break 's/^(.+) if (.+)$/seq _regexp-break %1; breakpoint mod -c %2/'
```