### PR TITLE
Fix how sequence handles initial commands

### DIFF
--- a/commands/FBDebugCommands.py
+++ b/commands/FBDebugCommands.py
@@ -395,6 +395,13 @@ class FBSequenceCommand(fb.FBCommand):
     # The full unsplit command is in position 0.
     sequence = arguments[1:]
     for command in sequence:
-      interpreter.HandleCommand(command.strip(), self.context, self.result)
-      if not self.result.Succeeded():
-        break
+      object = lldb.SBCommandReturnObject()
+      interpreter.HandleCommand(command.strip(), self.context, object)
+      if object.GetOutput():
+        print >>self.result, object.GetOutput().strip()
+
+      if not object.Succeeded():
+        if object.GetError():
+          self.result.SetError(object.GetError())
+        self.result.SetStatus(object.GetStatus())
+        return


### PR DESCRIPTION
This initial version of `sequence` #233 would only print the output from the last command, because it reused the same `SBCommandReturnObject` for each command, which doesn't work due lldb calling `Clear()` within `HandleCommand`.

With this change, a fresh `SBCommandReturnObject` is used for each given command. If this temporary return object has output, it is appended to the main result object (`self.result`). If the command doesn't succeed, the error and status of the failed result are copied to the main `self.result`.