### PR TITLE
Add heapfrom command

### DIFF
--- a/commands/FBDebugCommands.py
+++ b/commands/FBDebugCommands.py
@@ -391,6 +391,10 @@ class FBHeapFromCommand(fb.FBCommand):
   def run(self, arguments, options):
     # This command is like `expression --synthetic-type false`, except only showing nested heap references.
     var = self.context.frame.var(arguments[0])
+    if not var or not var.IsValid():
+      self.result.SetError('No variable named "{}"'.format(arguments[0]))
+      return
+
     # Use the actual underlying structure of the variable, not the human friendly (synthetic) one.
     root = var.GetNonSyntheticValue()
 

--- a/commands/FBDebugCommands.py
+++ b/commands/FBDebugCommands.py
@@ -17,6 +17,7 @@ def lldbcommands():
     FBFindInstancesCommand(),
     FBMethodBreakpointEnableCommand(),
     FBMethodBreakpointDisableCommand(),
+    FBHeapFromCommand(),
     FBSequenceCommand(),
   ]
 

--- a/commands/FBDebugCommands.py
+++ b/commands/FBDebugCommands.py
@@ -422,7 +422,7 @@ class FBHeapFromCommand(fb.FBCommand):
 
     allocations = (addr for addr in pointers if isHeap(addr))
     for addr in allocations:
-        print >>self.result, '0x{addr:x}: {path}'.format(addr=addr, path=pointers[addr])
+        print >>self.result, '0x{addr:x} {path}'.format(addr=addr, path=pointers[addr])
     if not allocations:
         print >>self.result, "No heap addresses found"
 


### PR DESCRIPTION
This adds a `heapfrom` command, which shows the **heap** pointers that can be accessed **from** the contents of given variable (a struct). The output is similar to what is generated by `expression --flat --synthetic-type false`, except showing only paths that lead to heap addresses.