### PR TITLE
Added FBPrintWindow command

### DIFF
--- a/commands/FBPrintCommands.py
+++ b/commands/FBPrintCommands.py
@@ -52,6 +52,7 @@ class FBPrintViewHierarchyCommand(fb.FBCommand):
     return [
       fb.FBCommandArgument(short='-u', long='--up', arg='upwards', boolean=True, default=False, help='Print only the hierarchy directly above the view, up to its window.'),
       fb.FBCommandArgument(short='-d', long='--depth', arg='depth', type='int', default="0", help='Print only to a given depth. 0 indicates infinite depth.'),
+      fb.FBCommandArgument(short='-w', long='--window', arg='window', type='int', default="0", help='Specify the window to print a description of. Check which windows exist with "po (id)[[UIApplication sharedApplication] windows]".'),
     ]
 
   def args(self):
@@ -59,13 +60,19 @@ class FBPrintViewHierarchyCommand(fb.FBCommand):
 
   def run(self, arguments, options):
     maxDepth = int(options.depth)
+    window = int(options.window)
     isMac = runtimeHelpers.isMacintoshArch()
 
-    if arguments[0] == '__keyWindow_dynamic__':
-      arguments[0] = '(id)[[UIApplication sharedApplication] keyWindow]'
-
+    if window > 0:
+      if isMac:
+        arguments[0] = '(id)[[[[NSApplication sharedApplication] windows] objectAtIndex:' + str(window) + '] contentView]'
+      else:
+        arguments[0] = '(id)[[[UIApplication sharedApplication] windows] objectAtIndex:' + str(window) + ']'
+    elif arguments[0] == '__keyWindow_dynamic__':
       if isMac:
         arguments[0] = '(id)[[[[NSApplication sharedApplication] windows] objectAtIndex:0] contentView]'
+      else:
+        arguments[0] = '(id)[[UIApplication sharedApplication] keyWindow]'
 
     if options.upwards:
       view = arguments[0]

--- a/commands/FBPrintCommands.py
+++ b/commands/FBPrintCommands.py
@@ -20,6 +20,7 @@ import fblldbobjcruntimehelpers as runtimeHelpers
 def lldbcommands():
   return [
     FBPrintViewHierarchyCommand(),
+    FBPrintWindow(),
     FBPrintCoreAnimationTree(),
     FBPrintViewControllerHierarchyCommand(),
     FBPrintIsExecutingInAnimationBlockCommand(),
@@ -86,6 +87,18 @@ class FBPrintViewHierarchyCommand(fb.FBCommand):
         description = re.sub(r'%s.*\n' % (prefixToRemove), r'', description)
       print description
 
+class FBPrintWindow(fb.FBCommand):
+  def name(self):
+    return 'pwindow'
+
+  def description(self):
+    return 'Print the recursion description of a Window, specified by <windowIndex>. Check which windows exist with "po (id)[[UIApplication sharedApplication] windows]".'
+
+  def args(self):
+    return [ fb.FBCommandArgument(arg='windowIndex', type='int', help='The index of the Window to print a description of.', default=0) ]
+
+  def run(self, arguments, options):
+    lldb.debugger.HandleCommand('po (id)[[[[UIApplication sharedApplication] windows] objectAtIndex:' + arguments[0] + '] recursiveDescription]')
 
 class FBPrintCoreAnimationTree(fb.FBCommand):
   def name(self):


### PR DESCRIPTION
I've been working with input accessory views quite a bit. They've been annoying to debug because they don't live in the main key window, they are hosted in the Keyboard's window. I added a short chisel command locally to make printing a window easy. Let me know if this is something useful for the library. 