### PR TITLE
Fix issues found with sequence

### DIFF
--- a/commands/FBDebugCommands.py
+++ b/commands/FBDebugCommands.py
@@ -435,23 +435,53 @@ class FBSequenceCommand(fb.FBCommand):
     return 'Run commands in sequence, stopping on any error.'
 
   def lex(self, commandLine):
-    return commandLine.split(';')
+    return [command.strip() for command in commandLine.split(';')]
 
   def run(self, arguments, options):
-    interpreter = lldb.debugger.GetCommandInterpreter()
-    # The full unsplit command is in position 0.
-    sequence = arguments[1:]
-    for command in sequence:
-      command = command.strip()
-      if not command:
-        continue
-      object = lldb.SBCommandReturnObject()
-      interpreter.HandleCommand(command, self.context, object)
-      if object.GetOutput():
-        print >>self.result, object.GetOutput().strip()
+    # arguments contains the raw command first, followed by the split commands.
+    if len(arguments) == 1:
+      return
+    commands = filter(None, arguments[1:])
 
-      if not object.Succeeded():
-        if object.GetError():
-          self.result.SetError(object.GetError())
-        self.result.SetStatus(object.GetStatus())
+    interpreter = lldb.debugger.GetCommandInterpreter()
+
+    # Complete one command before running the next one in the sequence. Disable
+    # async to do this. Also, save the current async value to restore it later.
+    async = lldb.debugger.GetAsync()
+    lldb.debugger.SetAsync(False)
+
+    for command in commands[:-1]:
+      success = self.run_command(interpreter, command)
+      if not success:
+        lldb.debugger.SetAsync(async)
         return
+
+    # Restore original async value.
+    lldb.debugger.SetAsync(async)
+
+    # If the last command is `continue`, call Continue() on the process
+    # instead. This is done because HandleCommand('continue') has strange
+    # behavior, while calling Continue() works as expected.
+    last = commands[-1]
+    if self.is_continue(interpreter, last)
+      self.context.process.Continue()
+    else:
+      self.run_command(interpreter, last)
+
+  def run_command(self, interpreter, command):
+    ret = lldb.SBCommandReturnObject()
+    interpreter.HandleCommand(command, ret)
+    if ret.GetOutput():
+      print >>self.result, ret.GetOutput().strip()
+
+    if ret.Succeeded():
+      return True
+
+    self.result.SetError(ret.GetError())
+    self.result.SetStatus(ret.GetStatus())
+    return False
+
+  def is_continue(interpreter, command):
+    ret = lldb.SBCommandReturnObject()
+    interpreter.ResolveCommand(command, ret)
+    return ret.GetOutput() == 'process continue'


### PR DESCRIPTION
1. Call `HandleCommand()` without the context argument. This is because the context is essentially a cache, and its properties can be invalided by previous commands. For example if one command is `finish` then the `frame` property of the context will now be invalid and unusable. `HandleCommand()` without the context argument will use the current frame, for example.
2. Set the debugger to synchronous execution. Each command in the sequence must not run until the previous command has finished. If the debugger is in async mode, `HandleCommand()` can return asynchronously before the command has concluded.
3. Special case `continue` by calling directly `process.Continue()`. This is done as a workaround to `HandleCommand('continue')` not resulting in the expected result, it's as though the continue command is interrupted. Calling `Continue()` does result in the expected behavior.