### PR TITLE
fix #198 pblock & pproperties type erro

### DIFF
--- a/commands/FBClassDump.py
+++ b/commands/FBClassDump.py
@@ -111,7 +111,7 @@ class FBPrintBlock(fb.FBCommand):
     struct Block_literal_1 real = *((__bridge struct Block_literal_1 *)$block);
     NSMutableDictionary *dict = (id)[NSMutableDictionary dictionary];
     
-    [dict setObject:(id)[NSNumber numberWithLong:(long)real.invoke] forKey:@"invoke"];
+    [dict setValue:(id)[NSNumber numberWithLong:(long)real.invoke] forKey:@"invoke"];
     
     if (real.flags & BLOCK_HAS_SIGNATURE) {
       char *signature;
@@ -131,7 +131,7 @@ class FBPrintBlock(fb.FBCommand):
           [types addObject:(id)[NSString stringWithUTF8String:type]];
       }
       
-      [dict setObject:types forKey:@"signature"];
+      [dict setValue:types forKey:@"signature"];
     }
     
     RETURN(dict);

--- a/fblldbbase.py
+++ b/fblldbbase.py
@@ -150,7 +150,8 @@ RETURN_MACRO = """
     if (!IS_JSON_OBJ(ret)) {\
         (void)[NSException raise:@"Invalid RETURN argument" format:@""];\
     }\
-    NSDictionary *__dict = @{@"return":ret};\
+    NSMutableDictionary *__dict = (id)[NSMutableDictionary dictionary];\
+    [__dict setValue:(id)ret forKey:@"return"];\
     NSData *__data = (id)[NSJSONSerialization dataWithJSONObject:__dict options:0 error:NULL];\
     NSString *__str = (id)[[NSString alloc] initWithData:__data encoding:4];\
     (char *)[__str UTF8String];})


### PR DESCRIPTION
(lldb) pblock completion
error: error: cannot initialize a parameter of type 'id _Nonnull' with an rvalue of type 'NSString *'
passing argument to parameter 'aKey' here
error: cannot initialize a parameter of type 'id _Nonnull' with an rvalue of type 'NSString *'
passing argument to parameter 'aKey' here
error: error: cannot initialize a parameter of type 'id _Nonnull' with an rvalue of type 'NSString *'
passing argument to parameter 'aKey' here
error: cannot initialize a parameter of type 'id _Nonnull' with an rvalue of type 'NSString *'
passing argument to parameter 'aKey' here
Traceback (most recent call last):
File "/usr/local/opt/chisel/libexec/fblldb.py", line 83, in runCommand
command.run(args, options)
File "/usr/local/Cellar/chisel/1.5.0/libexec/commands/FBClassDump.py", line 142, in run
signature = json['signature']
TypeError: 'NoneType' object has no attribute 'getitem'