### PR TITLE
Fix issue with visualize

### DIFF
--- a/commands/FBVisualizationCommands.py
+++ b/commands/FBVisualizationCommands.py
@@ -34,7 +34,8 @@ def _showImage(commandForImage):
     else:
       raise
 
-  imageDataAddress = fb.evaluateObjectExpression('UIImagePNGRepresentation((id)' + commandForImage + ')')
+  toPNG = '(id)UIImagePNGRepresentation((id){})'.format(commandForImage)
+  imageDataAddress = fb.evaluateExpressionValue(toPNG, tryAllThreads=True).GetValue()
   imageBytesStartAddress = fb.evaluateExpression('(void *)[(id)' + imageDataAddress + ' bytes]')
   imageBytesLength = fb.evaluateExpression('(NSUInteger)[(id)' + imageDataAddress + ' length]')
 

--- a/fblldbbase.py
+++ b/fblldbbase.py
@@ -56,7 +56,7 @@ def importModule(frame, module):
 
 # evaluates expression in Objective-C++ context, so it will work even for
 # Swift projects
-def evaluateExpressionValue(expression, printErrors=True, language=lldb.eLanguageTypeObjC_plus_plus):
+def evaluateExpressionValue(expression, printErrors=True, language=lldb.eLanguageTypeObjC_plus_plus, tryAllThreads=False):
   frame = lldb.debugger.GetSelectedTarget().GetProcess().GetSelectedThread().GetSelectedFrame()
   options = lldb.SBExpressionOptions()
   options.SetLanguage(language)
@@ -70,8 +70,8 @@ def evaluateExpressionValue(expression, printErrors=True, language=lldb.eLanguag
   # Give evaluation more time.
   options.SetTimeoutInMicroSeconds(5000000) # 5s
 
-  # Chisel commands are not multithreaded.
-  options.SetTryAllThreads(False)
+  # Most Chisel commands are not multithreaded.
+  options.SetTryAllThreads(tryAllThreads)
 
   value = frame.EvaluateExpression(expression, options)
   error = value.GetError()


### PR DESCRIPTION
Fixes #215 and #177.

`UIImagePNGRepresentation()` is apparently multithreaded. However, by default Chisel disables other threads from running when evaluating expressions. This change exposes a keyword argument, `tryAllThreads`, which lets commands like `visualize` specify that certain expressions be evaluated with multithreading permitted.

Note that calling `visualize` with an `Optional` type will require unwrapping it. For example:

```
visualize icon.image()!
```

cc @cbowns