### PR TITLE
add short option for pviews to print class name of view only

### DIFF
--- a/commands/FBPrintCommands.py
+++ b/commands/FBPrintCommands.py
@@ -53,6 +53,7 @@ class FBPrintViewHierarchyCommand(fb.FBCommand):
       fb.FBCommandArgument(short='-u', long='--up', arg='upwards', boolean=True, default=False, help='Print only the hierarchy directly above the view, up to its window.'),
       fb.FBCommandArgument(short='-d', long='--depth', arg='depth', type='int', default="0", help='Print only to a given depth. 0 indicates infinite depth.'),
       fb.FBCommandArgument(short='-w', long='--window', arg='window', type='int', default="0", help='Specify the window to print a description of. Check which windows exist with "po (id)[[UIApplication sharedApplication] windows]".'),
+      fb.FBCommandArgument(short='-s', long='--short', arg='short', boolean=True, default=False, help='Print a short description of the view')
     ]
 
   def args(self):
@@ -92,6 +93,11 @@ class FBPrintViewHierarchyCommand(fb.FBCommand):
         prefixToRemove = separator * maxDepth + " "
         description += "\n"
         description = re.sub(r'%s.*\n' % (prefixToRemove), r'', description)
+
+      if options.short:
+        toRemove = ":.*(?:\n|$)"
+        description = re.sub(toRemove, r'>\n', description)
+
       print description
 
 class FBPrintCoreAnimationTree(fb.FBCommand):

--- a/commands/FBPrintCommands.py
+++ b/commands/FBPrintCommands.py
@@ -53,7 +53,8 @@ class FBPrintViewHierarchyCommand(fb.FBCommand):
       fb.FBCommandArgument(short='-u', long='--up', arg='upwards', boolean=True, default=False, help='Print only the hierarchy directly above the view, up to its window.'),
       fb.FBCommandArgument(short='-d', long='--depth', arg='depth', type='int', default="0", help='Print only to a given depth. 0 indicates infinite depth.'),
       fb.FBCommandArgument(short='-w', long='--window', arg='window', type='int', default="0", help='Specify the window to print a description of. Check which windows exist with "po (id)[[UIApplication sharedApplication] windows]".'),
-      fb.FBCommandArgument(short='-s', long='--short', arg='short', boolean=True, default=False, help='Print a short description of the view')
+      fb.FBCommandArgument(short='-s', long='--short', arg='short', boolean=True, default=False, help='Print a short description of the view'),
+      fb.FBCommandArgument(short='-m', long='--medium', arg='medium', boolean=True, default=False, help='Print a medium description of the view')
     ]
 
   def args(self):
@@ -96,6 +97,9 @@ class FBPrintViewHierarchyCommand(fb.FBCommand):
 
       if options.short:
         toRemove = ":.*(?:\n|$)"
+        description = re.sub(toRemove, r'>\n', description)
+      elif options.medium:
+        toRemove = ";.*(?:\n|$)"
         description = re.sub(toRemove, r'>\n', description)
 
       print description


### PR DESCRIPTION
add a `--short` option to `pviews`, so you get a sample output like. The intent is to let the user focus on the view hierarchy instead of the verbose details of each view's properties.

```
(lldb) pviews --short
<UIWindow>
   | <UIView>
   |    | <UIImageView>
   |    | <FloatingMenu.FloatingButton>
   |    |    | <UIImageView>
   |    |    | <UIImageView>
   |    | <_UILayoutGuide>
   |    | <_UILayoutGuide>
   | <UITransitionView>
   |    | <UIView>
   |    |    | <UIVisualEffectView>
   |    |    |    | <_UIVisualEffectBackdropView>
   |    |    |    | <_UIVisualEffectSubview>
   |    |    | <UILabel>
   |    |    | <UILabel>
   |    |    | <UILabel>
   |    |    | <UILabel>
   |    |    | <UILabel>
   |    |    | <FloatingMenu.FloatingButton>
   |    |    |    | <UIImageView>
   |    |    |    | <UIImageView>
   |    |    | <FloatingMenu.FloatingButton>
   |    |    |    | <UIImageView>
   |    |    |    | <UIImageView>
   |    |    | <FloatingMenu.FloatingButton>
   |    |    |    | <UIImageView>
   |    |    |    | <UIImageView>
   |    |    | <FloatingMenu.FloatingButton>
   |    |    |    | <UIImageView>
   |    |    |    | <UIImageView>
   |    |    | <FloatingMenu.FloatingButton>
   |    |    |    | <UIImageView>
   |    |    |    | <UIImageView>
   |    |    | <FloatingMenu.FloatingButton>
   |    |    |    | <UIImageView>
   |    |    |    | <UIImageView>
```