### PR TITLE
Change how presence of Chisel runtime is verified

### DIFF
--- a/commands/FBDebugCommands.py
+++ b/commands/FBDebugCommands.py
@@ -337,7 +337,8 @@ class FBFindInstancesCommand(fb.FBCommand):
 
   def loadChiselIfNecessary(self):
     target = lldb.debugger.GetSelectedTarget()
-    if target.module['Chisel']:
+    symbol_contexts = target.FindSymbols('PrintInstances', lldb.eSymbolTypeCode)
+    if any(ctx.symbol.IsValid() for ctx in symbol_contexts):
       return True
 
     path = self.chiselLibraryPath()


### PR DESCRIPTION
Instead of looking for a module by the name of Chisel, look for the `PrintInstances` symbol.

This allows Chisel to be statically linked, which could the simplest way to use `findinstances` on iOS devices.