### PR TITLE
Add evalfile command

### DIFF
--- a/commands/FBClassDump.py
+++ b/commands/FBClassDump.py
@@ -134,7 +134,7 @@ class FBPrintBlock(fb.FBCommand):
       [dict setObject:types forKey:@"signature"];
     }
     
-    RETURN(dict);
+    RETURN_JSON(dict);
     """
     command = string.Template(tmpString).substitute(block=block)
     json = fb.evaluate(command)
@@ -260,7 +260,7 @@ def getMethods(klass):
       
       [result addObject:m];
     }
-    RETURN(result);
+    RETURN_JSON(result);
   """
   command = string.Template(tmpString).substitute(cls=klass)
   methods = fb.evaluate(command)
@@ -302,10 +302,10 @@ def getProperties(klass):
           NSMutableDictionary *dict = (id)[NSMutableDictionary dictionary];
           
           char *name = (char *)property_getName(props[i]);
-          [dict setObject:(id)[NSString stringWithUTF8String:name] forKey:@"name"];
+          [dict setObject:(id)[NSString stringWithUTF8String:name] forKey:(id)@"name"];
           
           char *attrstr = (char *)property_getAttributes(props[i]);
-          [dict setObject:(id)[NSString stringWithUTF8String:attrstr] forKey:@"attributes_string"];
+          [dict setObject:(id)[NSString stringWithUTF8String:attrstr] forKey:(id)@"attributes_string"];
           
           NSMutableDictionary *attrsDict = (id)[NSMutableDictionary dictionary];
           unsigned int pcount;
@@ -313,13 +313,13 @@ def getProperties(klass):
           for (int i = 0; i < pcount; i++) {
               NSString *name = (id)[NSString stringWithUTF8String:(char *)attrs[i].name];
               NSString *value = (id)[NSString stringWithUTF8String:(char *)attrs[i].value];
-              [attrsDict setObject:value forKey:name];
+              [attrsDict setObject:value forKey:(id)name];
           }
-          [dict setObject:attrsDict forKey:@"attributes"];
+          [dict setObject:attrsDict forKey:(id)@"attributes"];
           
           [result addObject:dict];
       }
-      RETURN(result);
+      RETURN_JSON(result);
     """
   command = string.Template(tmpString).substitute(cls=klass)
   propsJson = fb.evaluate(command)


### PR DESCRIPTION
evalfile command can evaluate a multiline  source code from a file. You can also supply a argument after the file parameter. 

```objc
// /path/to/test.m

@import ObjectiveC.runtime;

NSMutableArray *result = (id)[NSMutableArray array];
unsigned int count;
objc_property_t *props = (objc_property_t *)class_copyPropertyList((Class)$arg0, &count);
for (int i = 0; i < count; i++) {
    char *name = (char *)property_getName(props[i]);
    [result addObject:(id)[NSString stringWithUTF8String:name]];
}
RETURN(result);
```
```bash
lldb> p/x (char*)NSClassFromString(@"UIView")
(char *) $35 = 0x00000001119a7ff8
lldb> evalfile  /path/to/test.m 0x00000001119a7ff8
<__NSArrayM 0x608000057040>(
hash,
superclass,
description,
debugDescription,
hash,
superclass,
description,
......
)
```