### PR TITLE
Add 'uikit' command to import UIKit

### DIFF
--- a/commands/FBImportCommands.py
+++ b/commands/FBImportCommands.py
@@ -13,7 +13,7 @@ import fblldbbase as fb
 def lldbcommands():
   return [ 
     ImportUIKitModule()
-    ]
+  ]
   
 class ImportUIKitModule(fb.FBCommand):
   def name(self):

--- a/commands/FBImportCommands.py
+++ b/commands/FBImportCommands.py
@@ -1,0 +1,28 @@
+#!/usr/bin/python
+
+# Copyright (c) 2014, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+
+import lldb
+import fblldbbase as fb
+
+def lldbcommands():
+  return [ 
+    ImportUIKitModule()
+    ]
+  
+class ImportUIKitModule(fb.FBCommand):
+  def name(self):
+    return 'uikit'
+    
+  def description(self):
+    return 'Imports the UIKit module to get access to the types while in lldb.'
+    
+  def run(self, arguments, options):
+    frame = lldb.debugger.GetSelectedTarget().GetProcess().GetSelectedThread().GetSelectedFrame()
+    fb.importModule(frame, 'UIKit')
+    


### PR DESCRIPTION
# `uikit` Shortcut For `e @import UIKit`
![Screen Shot 2019-03-19 at 11 40 51 AM](https://user-images.githubusercontent.com/12219300/54632758-0b531c00-4a3c-11e9-867f-47bfdfabdccd.png)

## How This Helps
A lot of people face the issue of [not being able to use UIKit types](https://stackoverflow.com/questions/18885255/why-cant-lldb-print-view-bounds) that comes with UIKit during a debugging session. To make it work, they could use `e @import UIKit`. However, this command is needed every time they start debugging and can get annoying to type. This shortcut reduces that into `uikit` with autocomplete. 

## Tests
I believe tests are not necessary for import. Let me know otherwise. 

## Possible Addition in the Future
This one just adds one command to the UIKit. In the future, someone may want to [import Foundation for MacOS developers](https://furbo.org/2015/05/11/an-import-ant-change-in-xcode/). But since I haven't developed for MacOS so I've omitted it here.