### PR TITLE
[Copyright] Add copyright header to all files, update to yearless variant in all files already containing a header

### DIFF
--- a/Chisel/Chisel-macOS/Chisel_macOS.h
+++ b/Chisel/Chisel-macOS/Chisel_macOS.h
@@ -1,3 +1,5 @@
+// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
 #import <Cocoa/Cocoa.h>
 
 //! Project version number for Chisel_macOS.

--- a/Chisel/Chisel/CHLAllocations.c
+++ b/Chisel/Chisel/CHLAllocations.c
@@ -1,4 +1,4 @@
-// Copyright 2004-present Facebook. All Rights Reserved.
+// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
 #include "CHLAllocations.h"
 

--- a/Chisel/Chisel/CHLAllocations.h
+++ b/Chisel/Chisel/CHLAllocations.h
@@ -1,4 +1,4 @@
-// Copyright 2004-present Facebook. All Rights Reserved.
+// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
 #include <malloc/malloc.h>
 

--- a/Chisel/Chisel/CHLObjcInstanceCommands.h
+++ b/Chisel/Chisel/CHLObjcInstanceCommands.h
@@ -1,4 +1,4 @@
-// Copyright 2004-present Facebook. All Rights Reserved.
+// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
 @class NSPredicate;
 

--- a/Chisel/Chisel/CHLObjcInstanceCommands.mm
+++ b/Chisel/Chisel/CHLObjcInstanceCommands.mm
@@ -1,4 +1,4 @@
-// Copyright 2004-present Facebook. All Rights Reserved.
+// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
 #import "CHLObjcInstanceCommands.h"
 

--- a/Chisel/Chisel/CHLObjcInstances.h
+++ b/Chisel/Chisel/CHLObjcInstances.h
@@ -1,4 +1,4 @@
-// Copyright 2004-present Facebook. All Rights Reserved.
+// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
 #if defined(__cplusplus)
 

--- a/Chisel/Chisel/CHLObjcInstances.mm
+++ b/Chisel/Chisel/CHLObjcInstances.mm
@@ -1,4 +1,4 @@
-// Copyright 2004-present Facebook. All Rights Reserved.
+// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
 #import "CHLObjcInstances.h"
 

--- a/Chisel/Chisel/CHLPredicateTools.h
+++ b/Chisel/Chisel/CHLPredicateTools.h
@@ -1,4 +1,4 @@
-// Copyright 2004-present Facebook. All Rights Reserved.
+// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
 #import <Foundation/Foundation.h>
 

--- a/Chisel/Chisel/CHLPredicateTools.m
+++ b/Chisel/Chisel/CHLPredicateTools.m
@@ -1,4 +1,4 @@
-// Copyright 2004-present Facebook. All Rights Reserved.
+// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
 #import "CHLPredicateTools.h"
 

--- a/Chisel/Chisel/Chisel.h
+++ b/Chisel/Chisel/Chisel.h
@@ -1,4 +1,4 @@
-// Copyright 2004-present Facebook. All Rights Reserved.
+// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
 #import <UIKit/UIKit.h>
 

--- a/Chisel/Chisel/zone_allocator.h
+++ b/Chisel/Chisel/zone_allocator.h
@@ -1,4 +1,4 @@
-// Copyright 2004-present Facebook. All Rights Reserved.
+// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
 #pragma once
 

--- a/Chisel/ChiselTests/ChiselTests.m
+++ b/Chisel/ChiselTests/ChiselTests.m
@@ -1,4 +1,4 @@
-// Copyright 2004-present Facebook. All Rights Reserved.
+// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
 #import <XCTest/XCTest.h>
 

--- a/commands/FBAccessibilityCommands.py
+++ b/commands/FBAccessibilityCommands.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python
 
-# Copyright (c) 2015, Facebook, Inc.
-# All rights reserved.
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree. An additional grant

--- a/commands/FBAutoLayoutCommands.py
+++ b/commands/FBAutoLayoutCommands.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python
 
-# Copyright (c) 2014, Facebook, Inc.
-# All rights reserved.
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree. An additional grant

--- a/commands/FBClassDump.py
+++ b/commands/FBClassDump.py
@@ -1,4 +1,11 @@
 #!/usr/bin/python
+
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+
 import string
 import lldb
 import fblldbbase as fb

--- a/commands/FBComponentCommands.py
+++ b/commands/FBComponentCommands.py
@@ -1,5 +1,11 @@
 #!/usr/bin/python
 
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+
 import os
 
 import lldb

--- a/commands/FBDebugCommands.py
+++ b/commands/FBDebugCommands.py
@@ -1,5 +1,11 @@
 #!/usr/bin/python
 
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+
 import lldb
 import fblldbbase as fb
 import fblldbobjcruntimehelpers as objc

--- a/commands/FBDelay.py
+++ b/commands/FBDelay.py
@@ -1,4 +1,11 @@
 #!/usr/bin/python
+
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+
 from threading import Timer
 import fblldbbase as fb
 import fblldbobjcruntimehelpers as runtimeHelpers

--- a/commands/FBDisplayCommands.py
+++ b/commands/FBDisplayCommands.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python
 
-# Copyright (c) 2014, Facebook, Inc.
-# All rights reserved.
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree. An additional grant

--- a/commands/FBFindCommands.py
+++ b/commands/FBFindCommands.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python
 
-# Copyright (c) 2014, Facebook, Inc.
-# All rights reserved.
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree. An additional grant

--- a/commands/FBFlickerCommands.py
+++ b/commands/FBFlickerCommands.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python
 
-# Copyright (c) 2014, Facebook, Inc.
-# All rights reserved.
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree. An additional grant

--- a/commands/FBImportCommands.py
+++ b/commands/FBImportCommands.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python
 
-# Copyright (c) 2014, Facebook, Inc.
-# All rights reserved.
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree. An additional grant

--- a/commands/FBInvocationCommands.py
+++ b/commands/FBInvocationCommands.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python
 
-# Copyright (c) 2014, Facebook, Inc.
-# All rights reserved.
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree. An additional grant

--- a/commands/FBPrintCommands.py
+++ b/commands/FBPrintCommands.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python
 
-# Copyright (c) 2014, Facebook, Inc.
-# All rights reserved.
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree. An additional grant

--- a/commands/FBTextInputCommands.py
+++ b/commands/FBTextInputCommands.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python
 
-# Copyright (c) 2016, Facebook, Inc.
-# All rights reserved.
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree. An additional grant

--- a/commands/FBVisualizationCommands.py
+++ b/commands/FBVisualizationCommands.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python
 
-# Copyright (c) 2014, Facebook, Inc.
-# All rights reserved.
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree. An additional grant

--- a/commands/FBXCTestCommands.py
+++ b/commands/FBXCTestCommands.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python
 
-# Copyright (c) 2017, Facebook, Inc.
-# All rights reserved.
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree. An additional grant

--- a/fblldb.py
+++ b/fblldb.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python
 
-# Copyright (c) 2014, Facebook, Inc.
-# All rights reserved.
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree. An additional grant

--- a/fblldbbase.py
+++ b/fblldbbase.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python
 
-# Copyright (c) 2014, Facebook, Inc.
-# All rights reserved.
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree. An additional grant

--- a/fblldbinputhelpers.py
+++ b/fblldbinputhelpers.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python
 
-# Copyright (c) 2014, Facebook, Inc.
-# All rights reserved.
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree. An additional grant

--- a/fblldbobjcruntimehelpers.py
+++ b/fblldbobjcruntimehelpers.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python
 
-# Copyright (c) 2014, Facebook, Inc.
-# All rights reserved.
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree. An additional grant

--- a/fblldbobjecthelpers.py
+++ b/fblldbobjecthelpers.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python
 
-# Copyright (c) 2014, Facebook, Inc.
-# All rights reserved.
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree. An additional grant

--- a/fblldbviewcontrollerhelpers.py
+++ b/fblldbviewcontrollerhelpers.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python
 
-# Copyright (c) 2014, Facebook, Inc.
-# All rights reserved.
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree. An additional grant

--- a/fblldbviewhelpers.py
+++ b/fblldbviewhelpers.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python
 
-# Copyright (c) 2014, Facebook, Inc.
-# All rights reserved.
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree. An additional grant


### PR DESCRIPTION
- All files in the repository need a copyright header, but some don't currently have one.
- This is a simple change to include it in all code-containing files.
- The new standard is to be yearless, so also updating across the board to utilize that style.