### PR TITLE
Remove reference to deleted FBPrintCoreAnimationTree

### DIFF
--- a/commands/FBPrintCommands.py
+++ b/commands/FBPrintCommands.py
@@ -18,7 +18,6 @@ import fblldbobjcruntimehelpers as runtimeHelpers
 def lldbcommands():
   return [
     FBPrintViewHierarchyCommand(),
-    FBPrintCoreAnimationTree(),
     FBPrintViewControllerHierarchyCommand(),
     FBPrintIsExecutingInAnimationBlockCommand(),
     FBPrintInheritanceHierarchy(),


### PR DESCRIPTION
Fixes incomplete change in #265. Reported by @JohnWong here https://github.com/facebook/chisel/commit/587a7c8c6d7514602df4b8704baa1901157dd6a4#commitcomment-35261207