### PR TITLE
Fix TypeError: 'SBAddress' object cannot be interpreted as an integer

### DIFF
--- a/commands/FBDebugCommands.py
+++ b/commands/FBDebugCommands.py
@@ -297,7 +297,7 @@ def switchBreakpointState(expression, on):
         for location in breakpoint:
             if location.IsEnabled() != on and (
                 expression_pattern.search(str(location))
-                or expression == hex(location.GetAddress())
+                or expression == hex(location.GetLoadAddress())
             ):
                 print(str(location))
                 location.SetEnabled(on)


### PR DESCRIPTION
Fix TypeError: 'SBAddress' object cannot be interpreted as an integer