### PR TITLE
Updates README.md to note brew path difference on M1 macs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Then add the following line to your `~/.lldbinit` file.
 command script import /usr/local/opt/chisel/libexec/fbchisellldb.py
 ```
 
+* Note that if you are installing on an M1 Mac, the path above should be `/opt/homebrew/opt/chisel/libexec/fbchisellldb.py` instead.
+
 Alternatively, download chisel and add the following line to your _~/.lldbinit_ file.
 
 ```Python


### PR DESCRIPTION
As per title, `brew` is installed  on a different path on Apple Silicon/M1 machines as per docs [here](https://docs.brew.sh/FAQ#why-should-i-install-homebrew-in-the-default-location)

This PR updates the README to indicate that.
